### PR TITLE
[FEATURE] Add hackathon CRUD service - Fixes #13

### DIFF
--- a/python-api/api/schemas/hackathon.py
+++ b/python-api/api/schemas/hackathon.py
@@ -1,0 +1,223 @@
+"""
+Pydantic schemas for hackathon endpoints.
+
+Defines request and response models for hackathon CRUD operations.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class HackathonStatus(str, Enum):
+    """Hackathon status enumeration."""
+    DRAFT = "draft"
+    UPCOMING = "upcoming"
+    ACTIVE = "active"
+    JUDGING = "judging"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class HackathonCreateRequest(BaseModel):
+    """
+    Request schema for creating a hackathon.
+
+    Attributes:
+        name: Hackathon name (required, 3-200 chars)
+        description: Detailed description (optional, max 5000 chars)
+        organizer_id: UUID of the organizer creating the hackathon
+        start_date: Start date/time (ISO 8601)
+        end_date: End date/time (ISO 8601)
+        registration_deadline: Optional registration cutoff date
+        max_participants: Optional participant limit
+        location: Physical location or "virtual"
+        website_url: Optional hackathon website URL
+        prizes: Optional prize information (JSON object)
+        rules: Optional rules and guidelines (text)
+        status: Initial status (defaults to "draft")
+    """
+    name: str = Field(..., min_length=3, max_length=200, description="Hackathon name")
+    description: Optional[str] = Field(None, max_length=5000, description="Hackathon description")
+    organizer_id: UUID = Field(..., description="UUID of the organizer")
+    start_date: datetime = Field(..., description="Start date/time")
+    end_date: datetime = Field(..., description="End date/time")
+    registration_deadline: Optional[datetime] = Field(None, description="Registration deadline")
+    max_participants: Optional[int] = Field(None, ge=1, description="Maximum participants")
+    location: str = Field(..., min_length=1, max_length=200, description="Location or 'virtual'")
+    website_url: Optional[str] = Field(None, max_length=500, description="Hackathon website")
+    prizes: Optional[dict] = Field(None, description="Prize information (JSON)")
+    rules: Optional[str] = Field(None, max_length=10000, description="Rules and guidelines")
+    status: HackathonStatus = Field(default=HackathonStatus.DRAFT, description="Hackathon status")
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Ensure name is not just whitespace."""
+        if not v.strip():
+            raise ValueError("Name cannot be empty or whitespace")
+        return v.strip()
+
+    @field_validator('location')
+    @classmethod
+    def validate_location(cls, v: str) -> str:
+        """Ensure location is not just whitespace."""
+        if not v.strip():
+            raise ValueError("Location cannot be empty or whitespace")
+        return v.strip()
+
+    @field_validator('end_date')
+    @classmethod
+    def validate_dates(cls, v: datetime, info) -> datetime:
+        """Ensure end_date is after start_date."""
+        if 'start_date' in info.data:
+            start_date = info.data['start_date']
+            if v <= start_date:
+                raise ValueError("end_date must be after start_date")
+        return v
+
+    @field_validator('registration_deadline')
+    @classmethod
+    def validate_registration_deadline(cls, v: Optional[datetime], info) -> Optional[datetime]:
+        """Ensure registration_deadline is before start_date."""
+        if v and 'start_date' in info.data:
+            start_date = info.data['start_date']
+            if v > start_date:
+                raise ValueError("registration_deadline must be before or equal to start_date")
+        return v
+
+
+class HackathonUpdateRequest(BaseModel):
+    """
+    Request schema for updating a hackathon.
+
+    All fields are optional. Only provided fields will be updated.
+
+    Attributes:
+        name: Updated hackathon name
+        description: Updated description
+        start_date: Updated start date/time
+        end_date: Updated end date/time
+        registration_deadline: Updated registration deadline
+        max_participants: Updated participant limit
+        location: Updated location
+        website_url: Updated website URL
+        prizes: Updated prize information
+        rules: Updated rules
+        status: Updated status
+    """
+    name: Optional[str] = Field(None, min_length=3, max_length=200)
+    description: Optional[str] = Field(None, max_length=5000)
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    registration_deadline: Optional[datetime] = None
+    max_participants: Optional[int] = Field(None, ge=1)
+    location: Optional[str] = Field(None, min_length=1, max_length=200)
+    website_url: Optional[str] = Field(None, max_length=500)
+    prizes: Optional[dict] = None
+    rules: Optional[str] = Field(None, max_length=10000)
+    status: Optional[HackathonStatus] = None
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure name is not just whitespace if provided."""
+        if v is not None and not v.strip():
+            raise ValueError("Name cannot be empty or whitespace")
+        return v.strip() if v else None
+
+    @field_validator('location')
+    @classmethod
+    def validate_location(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure location is not just whitespace if provided."""
+        if v is not None and not v.strip():
+            raise ValueError("Location cannot be empty or whitespace")
+        return v.strip() if v else None
+
+
+class HackathonResponse(BaseModel):
+    """
+    Response schema for a single hackathon.
+
+    Attributes:
+        hackathon_id: Unique hackathon identifier
+        name: Hackathon name
+        description: Hackathon description
+        organizer_id: UUID of the organizer
+        start_date: Start date/time
+        end_date: End date/time
+        registration_deadline: Registration deadline (if set)
+        max_participants: Maximum participants (if set)
+        location: Location
+        website_url: Website URL (if set)
+        prizes: Prize information (if set)
+        rules: Rules and guidelines (if set)
+        status: Current status
+        created_at: Creation timestamp
+        updated_at: Last update timestamp
+    """
+    hackathon_id: str
+    name: str
+    description: Optional[str]
+    organizer_id: str
+    start_date: datetime
+    end_date: datetime
+    registration_deadline: Optional[datetime]
+    max_participants: Optional[int]
+    location: str
+    website_url: Optional[str]
+    prizes: Optional[dict]
+    rules: Optional[str]
+    status: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class HackathonListResponse(BaseModel):
+    """
+    Response schema for listing hackathons.
+
+    Attributes:
+        hackathons: List of hackathon objects
+        total: Total number of hackathons matching filters
+        skip: Number of records skipped (pagination)
+        limit: Maximum records returned
+    """
+    hackathons: List[HackathonResponse]
+    total: int = Field(..., ge=0, description="Total matching hackathons")
+    skip: int = Field(default=0, ge=0, description="Records skipped")
+    limit: int = Field(default=100, ge=1, le=1000, description="Records per page")
+
+
+class HackathonDeleteResponse(BaseModel):
+    """
+    Response schema for hackathon deletion.
+
+    Attributes:
+        success: Whether deletion was successful
+        hackathon_id: ID of deleted hackathon
+        message: Confirmation message
+    """
+    success: bool
+    hackathon_id: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    """
+    Standard error response schema.
+
+    Attributes:
+        error: Error type/message
+        detail: Additional error details
+        status_code: HTTP status code
+    """
+    error: str
+    detail: Optional[str] = None
+    status_code: int

--- a/python-api/services/hackathon_service.py
+++ b/python-api/services/hackathon_service.py
@@ -1,0 +1,662 @@
+"""
+Hackathon Service
+
+Provides CRUD operations for hackathons with participant management,
+status validation, and soft delete functionality.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fastapi import HTTPException
+from fastapi import status as http_status
+from integrations.zerodb.client import ZeroDBClient
+from integrations.zerodb.exceptions import (
+    ZeroDBError,
+    ZeroDBNotFound,
+    ZeroDBTimeoutError,
+)
+from services.authorization import check_organizer
+
+# Configure logger
+logger = logging.getLogger(__name__)
+
+
+async def create_hackathon(
+    zerodb_client: ZeroDBClient,
+    name: str,
+    description: Optional[str],
+    organizer_id: str,
+    start_date: datetime,
+    end_date: datetime,
+    location: str,
+    registration_deadline: Optional[datetime] = None,
+    max_participants: Optional[int] = None,
+    website_url: Optional[str] = None,
+    prizes: Optional[Dict[str, Any]] = None,
+    rules: Optional[str] = None,
+    status: str = "draft",
+) -> Dict[str, Any]:
+    """
+    Create a new hackathon and automatically add creator as ORGANIZER.
+
+    This function handles the complete hackathon creation workflow:
+    1. Validates input data (dates, status)
+    2. Creates hackathon record in ZeroDB
+    3. Automatically adds creator as ORGANIZER in hackathon_participants
+    4. Returns the created hackathon
+
+    Args:
+        zerodb_client: ZeroDB client instance
+        name: Hackathon name (required, 3-200 chars)
+        description: Detailed description (optional, max 5000 chars)
+        organizer_id: UUID of the creating user
+        start_date: When hackathon begins
+        end_date: When hackathon ends
+        location: Physical location or "virtual"
+        registration_deadline: Optional registration cutoff
+        max_participants: Optional participant limit (>= 1)
+        website_url: Optional website URL
+        prizes: Optional prize information as dict
+        rules: Optional rules text
+        status: Initial status (default: "draft")
+
+    Returns:
+        Dict with hackathon data including hackathon_id
+
+    Raises:
+        HTTPException: 400 for validation errors
+        HTTPException: 500 for database errors
+        HTTPException: 504 for timeout errors
+
+    Performance:
+        Should complete in < 300ms for typical operations
+
+    Example:
+        >>> client = ZeroDBClient(api_key="...", project_id="...")
+        >>> hackathon = await create_hackathon(
+        ...     zerodb_client=client,
+        ...     name="AI Hackathon 2025",
+        ...     description="Build AI apps",
+        ...     organizer_id="user-123",
+        ...     start_date=datetime(2025, 3, 1),
+        ...     end_date=datetime(2025, 3, 3),
+        ...     location="San Francisco",
+        ...     status="draft"
+        ... )
+        >>> print(hackathon['hackathon_id'])
+        'hack-abc-123'
+    """
+    try:
+        # Step 1: Validate status
+        valid_statuses = ["draft", "upcoming", "active", "judging", "completed", "cancelled"]
+        if status not in valid_statuses:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid status '{status}'. Must be one of: {', '.join(valid_statuses)}",
+            )
+
+        # Step 2: Validate dates
+        if end_date <= start_date:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail="end_date must be after start_date",
+            )
+
+        if registration_deadline and registration_deadline > start_date:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail="registration_deadline must be before or equal to start_date",
+            )
+
+        # Step 3: Create hackathon record
+        hackathon_id = str(uuid.uuid4())
+        now = datetime.utcnow()
+
+        hackathon_row = {
+            "hackathon_id": hackathon_id,
+            "name": name.strip(),
+            "description": description,
+            "organizer_id": organizer_id,
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "registration_deadline": registration_deadline.isoformat() if registration_deadline else None,
+            "max_participants": max_participants,
+            "location": location.strip(),
+            "website_url": website_url,
+            "prizes": prizes,
+            "rules": rules,
+            "status": status,
+            "is_deleted": False,
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+
+        logger.info(f"Creating hackathon: {name} (ID: {hackathon_id})")
+        await zerodb_client.tables.insert_rows(
+            "hackathons",
+            rows=[hackathon_row],
+        )
+
+        # Step 4: Add creator as ORGANIZER participant
+        participant_id = str(uuid.uuid4())
+        participant_row = {
+            "participant_id": participant_id,
+            "hackathon_id": hackathon_id,
+            "user_id": organizer_id,
+            "role": "ORGANIZER",
+            "status": "approved",
+            "joined_at": now.isoformat(),
+        }
+
+        logger.info(f"Adding creator {organizer_id} as ORGANIZER for hackathon {hackathon_id}")
+        await zerodb_client.tables.insert_rows(
+            "hackathon_participants",
+            rows=[participant_row],
+        )
+
+        logger.info(
+            f"Successfully created hackathon {hackathon_id} with ORGANIZER {organizer_id}"
+        )
+
+        return {
+            **hackathon_row,
+            "hackathon_id": hackathon_id,
+        }
+
+    except HTTPException:
+        # Re-raise HTTPException as-is
+        raise
+
+    except ZeroDBTimeoutError as e:
+        logger.error(f"Timeout creating hackathon: {str(e)}")
+        raise HTTPException(
+            status_code=http_status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="Hackathon creation timed out. Please try again.",
+        )
+
+    except (ZeroDBError, ZeroDBNotFound) as e:
+        logger.error(
+            f"ZeroDB error creating hackathon: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create hackathon. Please contact support.",
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Unexpected error creating hackathon: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create hackathon. Please contact support.",
+        )
+
+
+async def get_hackathon(
+    zerodb_client: ZeroDBClient,
+    hackathon_id: str,
+    include_deleted: bool = False,
+) -> Dict[str, Any]:
+    """
+    Get a single hackathon by ID.
+
+    Retrieves hackathon details from ZeroDB. By default, excludes soft-deleted hackathons.
+
+    Args:
+        zerodb_client: ZeroDB client instance
+        hackathon_id: UUID of the hackathon
+        include_deleted: If True, include soft-deleted hackathons
+
+    Returns:
+        Dict with hackathon data
+
+    Raises:
+        HTTPException: 404 if hackathon not found or is deleted
+        HTTPException: 500 for database errors
+        HTTPException: 504 for timeout errors
+
+    Performance:
+        Should complete in < 100ms for typical queries
+
+    Example:
+        >>> client = ZeroDBClient(api_key="...", project_id="...")
+        >>> hackathon = await get_hackathon(client, "hack-123")
+        >>> print(hackathon['name'])
+        'AI Hackathon 2025'
+    """
+    try:
+        logger.debug(f"Retrieving hackathon {hackathon_id}")
+
+        hackathons = await zerodb_client.tables.query_rows(
+            "hackathons",
+            filter={"hackathon_id": hackathon_id},
+        )
+
+        if not hackathons or len(hackathons) == 0:
+            logger.warning(f"Hackathon {hackathon_id} not found")
+            raise HTTPException(
+                status_code=http_status.HTTP_404_NOT_FOUND,
+                detail=f"Hackathon {hackathon_id} not found",
+            )
+
+        hackathon = hackathons[0]
+
+        # Check if soft-deleted
+        if hackathon.get("is_deleted", False) and not include_deleted:
+            logger.warning(f"Hackathon {hackathon_id} is deleted")
+            raise HTTPException(
+                status_code=http_status.HTTP_404_NOT_FOUND,
+                detail=f"Hackathon {hackathon_id} not found",
+            )
+
+        logger.info(f"Retrieved hackathon {hackathon_id}: {hackathon.get('name')}")
+        return hackathon
+
+    except HTTPException:
+        raise
+
+    except ZeroDBTimeoutError as e:
+        logger.error(f"Timeout retrieving hackathon {hackathon_id}: {str(e)}")
+        raise HTTPException(
+            status_code=http_status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="Request timed out. Please try again.",
+        )
+
+    except (ZeroDBError, ZeroDBNotFound) as e:
+        logger.error(
+            f"ZeroDB error retrieving hackathon {hackathon_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve hackathon. Please contact support.",
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Unexpected error retrieving hackathon {hackathon_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve hackathon. Please contact support.",
+        )
+
+
+async def list_hackathons(
+    zerodb_client: ZeroDBClient,
+    skip: int = 0,
+    limit: int = 100,
+    status_filter: Optional[str] = None,
+    include_deleted: bool = False,
+) -> Dict[str, Any]:
+    """
+    List hackathons with pagination and filtering.
+
+    Retrieves paginated list of hackathons. Supports filtering by status.
+    Excludes soft-deleted hackathons by default.
+
+    Args:
+        zerodb_client: ZeroDB client instance
+        skip: Number of records to skip (default: 0)
+        limit: Maximum records to return (default: 100, max: 1000)
+        status_filter: Optional filter by status
+        include_deleted: If True, include soft-deleted hackathons
+
+    Returns:
+        Dict with keys:
+        - hackathons: List of hackathon objects
+        - total: Total number of matching hackathons
+        - skip: Number skipped
+        - limit: Limit applied
+
+    Raises:
+        HTTPException: 400 for invalid pagination parameters
+        HTTPException: 500 for database errors
+        HTTPException: 504 for timeout errors
+
+    Performance:
+        Should complete in < 500ms for typical queries
+
+    Example:
+        >>> client = ZeroDBClient(api_key="...", project_id="...")
+        >>> result = await list_hackathons(client, skip=0, limit=10, status_filter="active")
+        >>> print(f"Found {result['total']} active hackathons")
+        Found 5 active hackathons
+    """
+    try:
+        # Validate pagination
+        if skip < 0:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail="skip must be >= 0",
+            )
+
+        if limit < 1 or limit > 1000:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail="limit must be between 1 and 1000",
+            )
+
+        logger.info(f"Listing hackathons (skip={skip}, limit={limit}, status={status_filter})")
+
+        # Build filter
+        query_filter = {}
+        if status_filter:
+            query_filter["status"] = status_filter
+        if not include_deleted:
+            query_filter["is_deleted"] = False
+
+        # Query hackathons
+        all_hackathons = await zerodb_client.tables.query_rows(
+            "hackathons",
+            filter=query_filter if query_filter else None,
+        )
+
+        total = len(all_hackathons)
+
+        # Apply pagination
+        hackathons = all_hackathons[skip : skip + limit]
+
+        logger.info(f"Retrieved {len(hackathons)} of {total} hackathons")
+
+        return {
+            "hackathons": hackathons,
+            "total": total,
+            "skip": skip,
+            "limit": limit,
+        }
+
+    except HTTPException:
+        raise
+
+    except ZeroDBTimeoutError as e:
+        logger.error(f"Timeout listing hackathons: {str(e)}")
+        raise HTTPException(
+            status_code=http_status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="Request timed out. Please try again.",
+        )
+
+    except (ZeroDBError, ZeroDBNotFound) as e:
+        logger.error(
+            f"ZeroDB error listing hackathons: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list hackathons. Please contact support.",
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Unexpected error listing hackathons: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list hackathons. Please contact support.",
+        )
+
+
+async def update_hackathon(
+    zerodb_client: ZeroDBClient,
+    hackathon_id: str,
+    user_id: str,
+    update_data: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Update a hackathon (ORGANIZER only).
+
+    Updates hackathon fields. Only users with ORGANIZER role can update.
+    Validates status transitions and date consistency.
+
+    Args:
+        zerodb_client: ZeroDB client instance
+        hackathon_id: UUID of hackathon to update
+        user_id: UUID of user attempting update
+        update_data: Dict of fields to update
+
+    Returns:
+        Dict with updated hackathon data
+
+    Raises:
+        HTTPException: 403 if user is not ORGANIZER
+        HTTPException: 404 if hackathon not found
+        HTTPException: 400 for validation errors
+        HTTPException: 500 for database errors
+        HTTPException: 504 for timeout errors
+
+    Performance:
+        Should complete in < 300ms for typical operations
+
+    Example:
+        >>> client = ZeroDBClient(api_key="...", project_id="...")
+        >>> updated = await update_hackathon(
+        ...     zerodb_client=client,
+        ...     hackathon_id="hack-123",
+        ...     user_id="user-456",
+        ...     update_data={"status": "active", "max_participants": 100}
+        ... )
+        >>> print(updated['status'])
+        'active'
+    """
+    try:
+        # Step 1: Check authorization (ORGANIZER role required)
+        logger.info(f"Checking ORGANIZER authorization for user {user_id} on hackathon {hackathon_id}")
+        await check_organizer(
+            zerodb_client=zerodb_client,
+            user_id=user_id,
+            hackathon_id=hackathon_id,
+        )
+
+        # Step 2: Get current hackathon
+        hackathon = await get_hackathon(zerodb_client, hackathon_id)
+
+        # Step 3: Validate update data
+        if "status" in update_data:
+            valid_statuses = ["draft", "upcoming", "active", "judging", "completed", "cancelled"]
+            if update_data["status"] not in valid_statuses:
+                raise HTTPException(
+                    status_code=http_status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid status. Must be one of: {', '.join(valid_statuses)}",
+                )
+
+        # Validate dates if both are provided in update or one is provided
+        start_date = update_data.get("start_date")
+        end_date = update_data.get("end_date")
+
+        # Convert to datetime if provided as strings
+        if isinstance(start_date, str):
+            start_date = datetime.fromisoformat(start_date.replace('Z', '+00:00'))
+        if isinstance(end_date, str):
+            end_date = datetime.fromisoformat(end_date.replace('Z', '+00:00'))
+
+        # Get existing dates if not being updated
+        if start_date is None and "start_date" in hackathon:
+            existing_start = hackathon["start_date"]
+            if isinstance(existing_start, str):
+                start_date = datetime.fromisoformat(existing_start.replace('Z', '+00:00'))
+        if end_date is None and "end_date" in hackathon:
+            existing_end = hackathon["end_date"]
+            if isinstance(existing_end, str):
+                end_date = datetime.fromisoformat(existing_end.replace('Z', '+00:00'))
+
+        if start_date and end_date and end_date <= start_date:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail="end_date must be after start_date",
+            )
+
+        # Step 4: Prepare update
+        update_fields = {}
+        for key, value in update_data.items():
+            if value is not None:  # Only update non-None values
+                # Convert datetime to ISO string for ZeroDB
+                if isinstance(value, datetime):
+                    update_fields[key] = value.isoformat()
+                else:
+                    update_fields[key] = value
+
+        # Add updated_at timestamp
+        update_fields["updated_at"] = datetime.utcnow().isoformat()
+
+        # Step 5: Perform update
+        logger.info(f"Updating hackathon {hackathon_id} with fields: {list(update_fields.keys())}")
+        await zerodb_client.tables.update_rows(
+            "hackathons",
+            filter={"hackathon_id": hackathon_id},
+            update={"$set": update_fields},
+        )
+
+        # Step 6: Get updated hackathon
+        updated_hackathon = await get_hackathon(zerodb_client, hackathon_id)
+
+        logger.info(f"Successfully updated hackathon {hackathon_id}")
+        return updated_hackathon
+
+    except HTTPException:
+        raise
+
+    except ZeroDBTimeoutError as e:
+        logger.error(f"Timeout updating hackathon {hackathon_id}: {str(e)}")
+        raise HTTPException(
+            status_code=http_status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="Update timed out. Please try again.",
+        )
+
+    except (ZeroDBError, ZeroDBNotFound) as e:
+        logger.error(
+            f"ZeroDB error updating hackathon {hackathon_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update hackathon. Please contact support.",
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Unexpected error updating hackathon {hackathon_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update hackathon. Please contact support.",
+        )
+
+
+async def delete_hackathon(
+    zerodb_client: ZeroDBClient,
+    hackathon_id: str,
+    user_id: str,
+) -> Dict[str, Any]:
+    """
+    Soft delete a hackathon (ORGANIZER only).
+
+    Marks hackathon as deleted (is_deleted=True) instead of removing the record.
+    This preserves data integrity and allows for recovery if needed.
+
+    Args:
+        zerodb_client: ZeroDB client instance
+        hackathon_id: UUID of hackathon to delete
+        user_id: UUID of user attempting deletion
+
+    Returns:
+        Dict with deletion confirmation:
+        - success: True
+        - hackathon_id: ID of deleted hackathon
+        - message: Confirmation message
+
+    Raises:
+        HTTPException: 403 if user is not ORGANIZER
+        HTTPException: 404 if hackathon not found
+        HTTPException: 500 for database errors
+        HTTPException: 504 for timeout errors
+
+    Performance:
+        Should complete in < 200ms for typical operations
+
+    Example:
+        >>> client = ZeroDBClient(api_key="...", project_id="...")
+        >>> result = await delete_hackathon(
+        ...     zerodb_client=client,
+        ...     hackathon_id="hack-123",
+        ...     user_id="user-456"
+        ... )
+        >>> print(result['success'])
+        True
+    """
+    try:
+        # Step 1: Check authorization (ORGANIZER role required)
+        logger.info(f"Checking ORGANIZER authorization for user {user_id} on hackathon {hackathon_id}")
+        await check_organizer(
+            zerodb_client=zerodb_client,
+            user_id=user_id,
+            hackathon_id=hackathon_id,
+        )
+
+        # Step 2: Verify hackathon exists and is not already deleted
+        hackathon = await get_hackathon(zerodb_client, hackathon_id)
+
+        if hackathon.get("is_deleted", False):
+            raise HTTPException(
+                status_code=http_status.HTTP_404_NOT_FOUND,
+                detail=f"Hackathon {hackathon_id} not found",
+            )
+
+        # Step 3: Soft delete (mark as deleted)
+        logger.info(f"Soft deleting hackathon {hackathon_id}")
+        await zerodb_client.tables.update_rows(
+            "hackathons",
+            filter={"hackathon_id": hackathon_id},
+            update={
+                "$set": {
+                    "is_deleted": True,
+                    "updated_at": datetime.utcnow().isoformat(),
+                }
+            },
+        )
+
+        logger.info(f"Successfully soft deleted hackathon {hackathon_id}")
+
+        return {
+            "success": True,
+            "hackathon_id": hackathon_id,
+            "message": "Hackathon successfully deleted",
+        }
+
+    except HTTPException:
+        raise
+
+    except ZeroDBTimeoutError as e:
+        logger.error(f"Timeout deleting hackathon {hackathon_id}: {str(e)}")
+        raise HTTPException(
+            status_code=http_status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="Deletion timed out. Please try again.",
+        )
+
+    except (ZeroDBError, ZeroDBNotFound) as e:
+        logger.error(
+            f"ZeroDB error deleting hackathon {hackathon_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete hackathon. Please contact support.",
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Unexpected error deleting hackathon {hackathon_id}: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete hackathon. Please contact support.",
+        )

--- a/python-api/tests/test_hackathon_service.py
+++ b/python-api/tests/test_hackathon_service.py
@@ -1,0 +1,650 @@
+"""
+Tests for Hackathon Service
+
+Comprehensive test suite for hackathon CRUD operations.
+Tests authorization, validation, error handling, and edge cases.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from integrations.zerodb.exceptions import (
+    ZeroDBAuthError,
+    ZeroDBError,
+    ZeroDBNotFound,
+    ZeroDBTimeoutError,
+)
+from services.hackathon_service import (
+    create_hackathon,
+    delete_hackathon,
+    get_hackathon,
+    list_hackathons,
+    update_hackathon,
+)
+
+
+# Fixtures
+@pytest.fixture
+def mock_zerodb_client():
+    """Create a mock ZeroDB client."""
+    client = MagicMock()
+    client.tables = MagicMock()
+    client.project_id = "test-project-123"
+    return client
+
+
+@pytest.fixture
+def sample_hackathon_data():
+    """Sample hackathon data for testing (matches existing service signature)."""
+    now = datetime.utcnow()
+    return {
+        "name": "AI Hackathon 2024",
+        "description": "Build AI-powered applications",  # Required in existing implementation
+        "organizer_id": str(uuid.uuid4()),
+        "start_date": now + timedelta(days=30),
+        "end_date": now + timedelta(days=32),
+        "location": "virtual",
+        "registration_deadline": now + timedelta(days=25),
+        "max_participants": 100,
+        "website_url": "https://aihack2024.com",
+        "prizes": {"first": 10000, "second": 5000, "third": 2500},
+        "rules": "All participants must follow code of conduct",
+        "status": "draft",
+    }
+
+
+@pytest.fixture
+def sample_hackathon_row(sample_hackathon_data):
+    """Sample hackathon row from ZeroDB."""
+    hackathon_id = str(uuid.uuid4())
+    now = datetime.utcnow()
+    # Convert datetimes to ISO strings (as stored in ZeroDB)
+    row_data = {
+        **sample_hackathon_data,
+        "start_date": sample_hackathon_data["start_date"].isoformat(),
+        "end_date": sample_hackathon_data["end_date"].isoformat(),
+        "registration_deadline": sample_hackathon_data["registration_deadline"].isoformat()
+            if sample_hackathon_data.get("registration_deadline") else None,
+    }
+    return {
+        "hackathon_id": hackathon_id,
+        **row_data,
+        "is_deleted": False,
+        "created_at": now.isoformat(),
+        "updated_at": now.isoformat(),
+    }
+
+
+# Tests for create_hackathon()
+class TestCreateHackathon:
+    """Tests for hackathon creation."""
+
+    @pytest.mark.asyncio
+    async def test_create_hackathon_success(self, mock_zerodb_client, sample_hackathon_data):
+        """Test successful hackathon creation."""
+        # Arrange
+        mock_zerodb_client.tables.insert_rows = AsyncMock(
+            return_value={"success": True, "row_ids": [str(uuid.uuid4())]}
+        )
+
+        # Act
+        result = await create_hackathon(
+            zerodb_client=mock_zerodb_client,
+            **sample_hackathon_data,
+        )
+
+        # Assert
+        assert "hackathon_id" in result
+        assert result["name"] == sample_hackathon_data["name"]
+        assert mock_zerodb_client.tables.insert_rows.call_count == 2  # hackathon + participant
+
+    @pytest.mark.asyncio
+    async def test_create_hackathon_invalid_dates(self, mock_zerodb_client, sample_hackathon_data):
+        """Test creation fails when end_date is before start_date."""
+        # Arrange
+        sample_hackathon_data["end_date"] = sample_hackathon_data["start_date"] - timedelta(days=1)
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await create_hackathon(
+                zerodb_client=mock_zerodb_client,
+                **sample_hackathon_data,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "end_date" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_create_hackathon_invalid_registration_deadline(
+        self, mock_zerodb_client, sample_hackathon_data
+    ):
+        """Test creation fails when registration_deadline is after start_date."""
+        # Arrange
+        sample_hackathon_data["registration_deadline"] = (
+            sample_hackathon_data["start_date"] + timedelta(days=1)
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await create_hackathon(
+                zerodb_client=mock_zerodb_client,
+                **sample_hackathon_data,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "registration_deadline" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_create_hackathon_invalid_status(self, mock_zerodb_client, sample_hackathon_data):
+        """Test creation fails with invalid status."""
+        # Arrange
+        sample_hackathon_data["status"] = "invalid_status"
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await create_hackathon(
+                zerodb_client=mock_zerodb_client,
+                **sample_hackathon_data,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "status" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_create_hackathon_database_timeout(
+        self, mock_zerodb_client, sample_hackathon_data
+    ):
+        """Test creation handles database timeout."""
+        # Arrange
+        mock_zerodb_client.tables.insert_rows = AsyncMock(
+            side_effect=ZeroDBTimeoutError("Request timeout")
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await create_hackathon(
+                zerodb_client=mock_zerodb_client,
+                **sample_hackathon_data,
+            )
+
+        assert exc_info.value.status_code == 504
+
+    @pytest.mark.asyncio
+    async def test_create_hackathon_database_error(
+        self, mock_zerodb_client, sample_hackathon_data
+    ):
+        """Test creation handles database errors."""
+        # Arrange
+        mock_zerodb_client.tables.insert_rows = AsyncMock(
+            side_effect=ZeroDBError("Database error")
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await create_hackathon(
+                zerodb_client=mock_zerodb_client,
+                **sample_hackathon_data,
+            )
+
+        assert exc_info.value.status_code == 500
+
+
+# Tests for get_hackathon()
+class TestGetHackathon:
+    """Tests for retrieving a hackathon."""
+
+    @pytest.mark.asyncio
+    async def test_get_hackathon_success(self, mock_zerodb_client, sample_hackathon_row):
+        """Test successfully retrieving a hackathon."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            return_value=[sample_hackathon_row]
+        )
+
+        # Act
+        result = await get_hackathon(
+            zerodb_client=mock_zerodb_client,
+            hackathon_id=hackathon_id,
+        )
+
+        # Assert
+        assert result["hackathon_id"] == hackathon_id
+        assert result["name"] == sample_hackathon_row["name"]
+        mock_zerodb_client.tables.query_rows.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_hackathon_not_found(self, mock_zerodb_client):
+        """Test retrieving non-existent hackathon."""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        mock_zerodb_client.tables.query_rows = AsyncMock(return_value=[])
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await get_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+            )
+
+        assert exc_info.value.status_code == 404
+        assert "not found" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_get_hackathon_deleted(self, mock_zerodb_client, sample_hackathon_row):
+        """Test retrieving soft-deleted hackathon (should fail by default)."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        sample_hackathon_row["is_deleted"] = True
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            return_value=[sample_hackathon_row]
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await get_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+                include_deleted=False,
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_hackathon_database_timeout(self, mock_zerodb_client):
+        """Test get handles database timeout."""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            side_effect=ZeroDBTimeoutError("Request timeout")
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await get_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+            )
+
+        assert exc_info.value.status_code == 504
+
+
+# Tests for list_hackathons()
+class TestListHackathons:
+    """Tests for listing hackathons."""
+
+    @pytest.mark.asyncio
+    async def test_list_hackathons_success(self, mock_zerodb_client, sample_hackathon_row):
+        """Test successfully listing hackathons."""
+        # Arrange
+        hackathons = [sample_hackathon_row, {**sample_hackathon_row, "hackathon_id": str(uuid.uuid4())}]
+        mock_zerodb_client.tables.query_rows = AsyncMock(return_value=hackathons)
+
+        # Act
+        result = await list_hackathons(
+            zerodb_client=mock_zerodb_client,
+            skip=0,
+            limit=10,
+        )
+
+        # Assert
+        assert "hackathons" in result
+        assert "total" in result
+        assert result["total"] == 2
+        assert len(result["hackathons"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_hackathons_with_status_filter(
+        self, mock_zerodb_client, sample_hackathon_row
+    ):
+        """Test listing hackathons with status filter."""
+        # Arrange
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            return_value=[sample_hackathon_row]
+        )
+
+        # Act
+        result = await list_hackathons(
+            zerodb_client=mock_zerodb_client,
+            status_filter="draft",
+            skip=0,
+            limit=10,
+        )
+
+        # Assert
+        assert result["total"] == 1
+        # Verify filter was passed
+        call_args = mock_zerodb_client.tables.query_rows.call_args
+        assert call_args[1]["filter"]["status"] == "draft"
+
+    @pytest.mark.asyncio
+    async def test_list_hackathons_empty_result(self, mock_zerodb_client):
+        """Test listing hackathons returns empty list."""
+        # Arrange
+        mock_zerodb_client.tables.query_rows = AsyncMock(return_value=[])
+
+        # Act
+        result = await list_hackathons(
+            zerodb_client=mock_zerodb_client,
+            skip=0,
+            limit=10,
+        )
+
+        # Assert
+        assert result["hackathons"] == []
+        assert result["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_hackathons_pagination(self, mock_zerodb_client, sample_hackathon_row):
+        """Test hackathon listing with pagination."""
+        # Arrange
+        hackathons = [sample_hackathon_row] * 100
+        mock_zerodb_client.tables.query_rows = AsyncMock(return_value=hackathons)
+
+        # Act
+        result = await list_hackathons(
+            zerodb_client=mock_zerodb_client,
+            skip=10,
+            limit=20,
+        )
+
+        # Assert
+        assert result["skip"] == 10
+        assert result["limit"] == 20
+        assert len(result["hackathons"]) == 20  # Should return 20 items from skip=10
+
+    @pytest.mark.asyncio
+    async def test_list_hackathons_invalid_pagination(self, mock_zerodb_client):
+        """Test list with invalid pagination parameters."""
+        # Act & Assert - negative skip
+        with pytest.raises(HTTPException) as exc_info:
+            await list_hackathons(
+                zerodb_client=mock_zerodb_client,
+                skip=-1,
+                limit=10,
+            )
+
+        assert exc_info.value.status_code == 400
+
+        # Act & Assert - limit too large
+        with pytest.raises(HTTPException) as exc_info:
+            await list_hackathons(
+                zerodb_client=mock_zerodb_client,
+                skip=0,
+                limit=2000,
+            )
+
+        assert exc_info.value.status_code == 400
+
+
+# Tests for update_hackathon()
+class TestUpdateHackathon:
+    """Tests for updating hackathons."""
+
+    @pytest.mark.asyncio
+    async def test_update_hackathon_success(
+        self, mock_zerodb_client, sample_hackathon_row
+    ):
+        """Test successfully updating a hackathon."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        organizer_id = sample_hackathon_row["organizer_id"]
+        update_data = {
+            "name": "Updated Hackathon Name",
+            "description": "Updated description",
+        }
+
+        # Mock get existing hackathon
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            side_effect=[
+                [{"user_id": organizer_id, "role": "organizer", "hackathon_id": hackathon_id}],  # Auth check
+                [sample_hackathon_row],  # Get hackathon (first call in update)
+                [{**sample_hackathon_row, **update_data}],  # Get updated hackathon
+            ]
+        )
+
+        # Mock update operation
+        mock_zerodb_client.tables.update_rows = AsyncMock(return_value={"success": True})
+
+        # Act
+        result = await update_hackathon(
+            zerodb_client=mock_zerodb_client,
+            hackathon_id=hackathon_id,
+            user_id=organizer_id,
+            update_data=update_data,
+        )
+
+        # Assert
+        assert result["name"] == update_data["name"]
+        mock_zerodb_client.tables.update_rows.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_hackathon_not_found(self, mock_zerodb_client):
+        """Test updating non-existent hackathon."""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+
+        # Mock authorization success
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            side_effect=[
+                [{"user_id": user_id, "role": "organizer", "hackathon_id": hackathon_id}],  # Auth
+                [],  # Hackathon not found
+            ]
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await update_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+                user_id=user_id,
+                update_data={"name": "New Name"},
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_update_hackathon_unauthorized(
+        self, mock_zerodb_client, sample_hackathon_row
+    ):
+        """Test updating hackathon without organizer permission."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        unauthorized_user_id = str(uuid.uuid4())
+
+        # Mock authorization failure
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            return_value=[]  # No participant record - unauthorized
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await update_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+                user_id=unauthorized_user_id,
+                update_data={"name": "Hacked Name"},
+            )
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_update_hackathon_invalid_dates(
+        self, mock_zerodb_client, sample_hackathon_row
+    ):
+        """Test update fails with invalid date range."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        organizer_id = sample_hackathon_row["organizer_id"]
+
+        # Mock authorization and get hackathon
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            side_effect=[
+                [{"user_id": organizer_id, "role": "organizer", "hackathon_id": hackathon_id}],
+                [sample_hackathon_row],
+            ]
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await update_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+                user_id=organizer_id,
+                update_data={"end_date": datetime.fromisoformat(sample_hackathon_row["start_date"]) - timedelta(days=1)},
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "end_date" in str(exc_info.value.detail).lower()
+
+
+# Tests for delete_hackathon()
+class TestDeleteHackathon:
+    """Tests for deleting hackathons."""
+
+    @pytest.mark.asyncio
+    async def test_delete_hackathon_success(
+        self, mock_zerodb_client, sample_hackathon_row
+    ):
+        """Test successfully deleting a hackathon."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        organizer_id = sample_hackathon_row["organizer_id"]
+
+        # Mock get hackathon and auth check
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            side_effect=[
+                [{"user_id": organizer_id, "role": "organizer", "hackathon_id": hackathon_id}],  # Auth
+                [sample_hackathon_row],  # Get hackathon
+            ]
+        )
+
+        # Mock delete operation
+        mock_zerodb_client.tables.update_rows = AsyncMock(
+            return_value={"success": True}
+        )
+
+        # Act
+        result = await delete_hackathon(
+            zerodb_client=mock_zerodb_client,
+            hackathon_id=hackathon_id,
+            user_id=organizer_id,
+        )
+
+        # Assert
+        assert result["success"] is True
+        assert result["hackathon_id"] == hackathon_id
+        mock_zerodb_client.tables.update_rows.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_hackathon_not_found(self, mock_zerodb_client):
+        """Test deleting non-existent hackathon."""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+
+        # Mock authorization success
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            side_effect=[
+                [{"user_id": user_id, "role": "organizer", "hackathon_id": hackathon_id}],  # Auth
+                [],  # Hackathon not found
+            ]
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+                user_id=user_id,
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_hackathon_unauthorized(
+        self, mock_zerodb_client, sample_hackathon_row
+    ):
+        """Test deleting hackathon without organizer permission."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        unauthorized_user_id = str(uuid.uuid4())
+
+        # Mock get hackathon
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            return_value=[]  # No participant - unauthorized
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+                user_id=unauthorized_user_id,
+            )
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_delete_hackathon_already_deleted(
+        self, mock_zerodb_client, sample_hackathon_row
+    ):
+        """Test deleting already deleted hackathon."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        organizer_id = sample_hackathon_row["organizer_id"]
+        sample_hackathon_row["is_deleted"] = True
+
+        # Mock authorization and get hackathon
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            side_effect=[
+                [{"user_id": organizer_id, "role": "organizer", "hackathon_id": hackathon_id}],
+                [sample_hackathon_row],
+            ]
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+                user_id=organizer_id,
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_hackathon_database_error(
+        self, mock_zerodb_client, sample_hackathon_row
+    ):
+        """Test delete handles database errors."""
+        # Arrange
+        hackathon_id = sample_hackathon_row["hackathon_id"]
+        organizer_id = sample_hackathon_row["organizer_id"]
+
+        # Mock get hackathon and auth
+        mock_zerodb_client.tables.query_rows = AsyncMock(
+            side_effect=[
+                [{"user_id": organizer_id, "role": "organizer", "hackathon_id": hackathon_id}],
+                [sample_hackathon_row],
+            ]
+        )
+
+        # Mock delete failure
+        mock_zerodb_client.tables.update_rows = AsyncMock(
+            side_effect=ZeroDBError("Database error")
+        )
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_hackathon(
+                zerodb_client=mock_zerodb_client,
+                hackathon_id=hackathon_id,
+                user_id=organizer_id,
+            )
+
+        assert exc_info.value.status_code == 500


### PR DESCRIPTION
Closes #13

## Summary
- Implement hackathon creation with auto-participant addition
- Add hackathon retrieval with soft-delete support
- Add hackathon listing with pagination and status filtering
- Add hackathon update with organizer authorization
- Add hackathon deletion with soft-delete
- Comprehensive test suite with 24 test cases

## Test Plan
- Run pytest tests/test_hackathon_service.py
- Verify all 24 tests pass
- Verify CRUD operations work correctly

## Risk/Rollback
- Low risk - new service only
- Rollback: Remove hackathon service files