### PR TITLE
[FEATURE] Add hackathon management endpoints - Fixes #17

### DIFF
--- a/python-api/api/routes/hackathons.py
+++ b/python-api/api/routes/hackathons.py
@@ -1,0 +1,548 @@
+"""
+Hackathon API Routes
+
+RESTful API endpoints for hackathon CRUD operations with authentication,
+authorization, and comprehensive error handling.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from api.dependencies import get_current_user
+from api.schemas.hackathon import (
+    ErrorResponse,
+    HackathonCreateRequest,
+    HackathonDeleteResponse,
+    HackathonListResponse,
+    HackathonResponse,
+    HackathonUpdateRequest,
+)
+from config import settings
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from integrations.zerodb.client import ZeroDBClient
+from services import hackathon_service
+
+# Configure logger
+logger = logging.getLogger(__name__)
+
+# Create router with prefix and tags
+router = APIRouter(
+    prefix="/api/v1/hackathons",
+    tags=["Hackathons"],
+    responses={
+        401: {"model": ErrorResponse, "description": "Unauthorized"},
+        403: {"model": ErrorResponse, "description": "Forbidden"},
+        404: {"model": ErrorResponse, "description": "Not Found"},
+        500: {"model": ErrorResponse, "description": "Internal Server Error"},
+        504: {"model": ErrorResponse, "description": "Gateway Timeout"},
+    },
+)
+
+
+def get_zerodb_client() -> ZeroDBClient:
+    """
+    Dependency to provide ZeroDB client instance.
+
+    Returns:
+        Configured ZeroDBClient instance
+
+    Raises:
+        HTTPException: 500 if ZeroDB credentials are not configured
+    """
+    try:
+        return ZeroDBClient(
+            api_key=settings.ZERODB_API_KEY,
+            project_id=settings.ZERODB_PROJECT_ID,
+            base_url=settings.ZERODB_BASE_URL,
+        )
+    except ValueError as e:
+        logger.error(f"ZeroDB client configuration error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database configuration error. Please contact support.",
+        )
+
+
+@router.post(
+    "",
+    response_model=HackathonResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a hackathon",
+    description="""
+    Create a new hackathon with the authenticated user as ORGANIZER.
+
+    The creator is automatically assigned the ORGANIZER role, granting them
+    full permissions to manage the hackathon including updates, deletions,
+    participant management, and judging configuration.
+
+    **Authentication Required:** Yes (JWT or API Key)
+
+    **Permissions:** Any authenticated user can create a hackathon
+
+    **Request Body:**
+    - name: Hackathon name (3-200 characters, required)
+    - description: Detailed description (optional, max 5000 chars)
+    - organizer_id: UUID of the organizer (must match authenticated user)
+    - start_date: Start date/time in ISO 8601 format (required)
+    - end_date: End date/time in ISO 8601 format (must be after start_date, required)
+    - location: Physical location or "virtual" (required)
+    - registration_deadline: Optional deadline in ISO 8601 (must be ≤ start_date)
+    - max_participants: Optional participant limit (≥ 1)
+    - website_url: Optional hackathon website URL
+    - prizes: Optional prize information as JSON object
+    - rules: Optional rules and guidelines text
+    - status: Initial status (default: "draft")
+
+    **Status Values:**
+    - draft: Being planned, not visible to public
+    - upcoming: Visible, accepting registrations
+    - active: Currently running
+    - judging: Submissions closed, judging in progress
+    - completed: Finished, results published
+    - cancelled: Cancelled
+
+    **Response:** Created hackathon with hackathon_id
+
+    **Error Responses:**
+    - 400: Validation error (invalid dates, status, etc.)
+    - 401: Not authenticated
+    - 500: Database error
+    - 504: Timeout
+    """,
+    responses={
+        201: {
+            "description": "Hackathon created successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "hackathon_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "name": "AI Hackathon 2025",
+                        "description": "Build AI-powered applications",
+                        "organizer_id": "user-123",
+                        "start_date": "2025-03-01T09:00:00Z",
+                        "end_date": "2025-03-03T18:00:00Z",
+                        "location": "San Francisco, CA",
+                        "status": "draft",
+                        "created_at": "2025-01-15T10:00:00Z",
+                        "updated_at": "2025-01-15T10:00:00Z",
+                    }
+                }
+            },
+        },
+        400: {
+            "description": "Validation error",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "Validation error",
+                        "detail": "end_date must be after start_date",
+                        "status_code": 400,
+                    }
+                }
+            },
+        },
+    },
+)
+async def create_hackathon(
+    request: HackathonCreateRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> HackathonResponse:
+    """
+    Create a new hackathon endpoint.
+
+    Validates request, creates hackathon, and adds creator as ORGANIZER.
+    """
+    logger.info(
+        f"Create hackathon request from user {current_user.get('id')}: {request.name}"
+    )
+
+    # Ensure organizer_id matches authenticated user
+    user_id = str(current_user.get("id"))
+    if str(request.organizer_id) != user_id:
+        logger.warning(
+            f"User {user_id} attempted to create hackathon with different organizer_id: {request.organizer_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="organizer_id must match authenticated user",
+        )
+
+    hackathon = await hackathon_service.create_hackathon(
+        zerodb_client=zerodb_client,
+        name=request.name,
+        description=request.description,
+        organizer_id=user_id,
+        start_date=request.start_date,
+        end_date=request.end_date,
+        location=request.location,
+        registration_deadline=request.registration_deadline,
+        max_participants=request.max_participants,
+        website_url=str(request.website_url) if request.website_url else None,
+        prizes=request.prizes,
+        rules=request.rules,
+        status=request.status.value,
+    )
+
+    logger.info(f"Hackathon created successfully: {hackathon['hackathon_id']}")
+    return HackathonResponse(**hackathon)
+
+
+@router.get(
+    "",
+    response_model=HackathonListResponse,
+    summary="List hackathons",
+    description="""
+    List hackathons with pagination and optional status filtering.
+
+    By default, returns active and upcoming hackathons. Soft-deleted
+    hackathons are excluded.
+
+    **Authentication Required:** Yes (JWT or API Key)
+
+    **Permissions:** Any authenticated user can list hackathons
+
+    **Query Parameters:**
+    - skip: Number of records to skip (default: 0, for pagination)
+    - limit: Maximum records to return (default: 100, max: 1000)
+    - status: Optional status filter (draft, upcoming, active, judging, completed, cancelled)
+
+    **Response:** Paginated list with total count
+
+    **Error Responses:**
+    - 400: Invalid pagination parameters
+    - 401: Not authenticated
+    - 500: Database error
+    - 504: Timeout
+    """,
+    responses={
+        200: {
+            "description": "Hackathons retrieved successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "hackathons": [
+                            {
+                                "hackathon_id": "550e8400-e29b-41d4-a716-446655440000",
+                                "name": "AI Hackathon 2025",
+                                "description": "Build AI apps",
+                                "start_date": "2025-03-01T09:00:00Z",
+                                "end_date": "2025-03-03T18:00:00Z",
+                                "status": "active",
+                                "location": "San Francisco",
+                            }
+                        ],
+                        "total": 1,
+                        "skip": 0,
+                        "limit": 100,
+                    }
+                }
+            },
+        }
+    },
+)
+async def list_hackathons(
+    skip: int = Query(default=0, ge=0, description="Number of records to skip"),
+    limit: int = Query(default=100, ge=1, le=1000, description="Maximum records to return"),
+    status: Optional[str] = Query(default=None, description="Filter by status"),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> HackathonListResponse:
+    """
+    List hackathons endpoint with pagination and filtering.
+    """
+    logger.info(
+        f"List hackathons request from user {current_user.get('id')} "
+        f"(skip={skip}, limit={limit}, status={status})"
+    )
+
+    result = await hackathon_service.list_hackathons(
+        zerodb_client=zerodb_client,
+        skip=skip,
+        limit=limit,
+        status_filter=status,
+        include_deleted=False,
+    )
+
+    logger.info(f"Returning {len(result['hackathons'])} of {result['total']} hackathons")
+    return HackathonListResponse(**result)
+
+
+@router.get(
+    "/{hackathon_id}",
+    response_model=HackathonResponse,
+    summary="Get hackathon details",
+    description="""
+    Retrieve detailed information about a specific hackathon.
+
+    Returns all hackathon fields including organizer info, dates,
+    participant counts, and current status.
+
+    **Authentication Required:** Yes (JWT or API Key)
+
+    **Permissions:** Any authenticated user can view hackathon details
+
+    **Path Parameters:**
+    - hackathon_id: UUID of the hackathon
+
+    **Response:** Complete hackathon details
+
+    **Error Responses:**
+    - 401: Not authenticated
+    - 404: Hackathon not found or deleted
+    - 500: Database error
+    - 504: Timeout
+    """,
+    responses={
+        200: {
+            "description": "Hackathon details retrieved successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "hackathon_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "name": "AI Hackathon 2025",
+                        "description": "Build AI-powered applications",
+                        "organizer_id": "user-123",
+                        "start_date": "2025-03-01T09:00:00Z",
+                        "end_date": "2025-03-03T18:00:00Z",
+                        "location": "San Francisco, CA",
+                        "max_participants": 100,
+                        "website_url": "https://aihack2025.com",
+                        "prizes": {"first": "$10,000", "second": "$5,000"},
+                        "rules": "Standard hackathon rules apply",
+                        "status": "active",
+                        "created_at": "2025-01-15T10:00:00Z",
+                        "updated_at": "2025-01-15T10:00:00Z",
+                    }
+                }
+            },
+        },
+        404: {
+            "description": "Hackathon not found",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "Not found",
+                        "detail": "Hackathon 550e8400-e29b-41d4-a716-446655440000 not found",
+                        "status_code": 404,
+                    }
+                }
+            },
+        },
+    },
+)
+async def get_hackathon(
+    hackathon_id: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> HackathonResponse:
+    """
+    Get hackathon details endpoint.
+    """
+    logger.info(
+        f"Get hackathon request from user {current_user.get('id')} for hackathon {hackathon_id}"
+    )
+
+    hackathon = await hackathon_service.get_hackathon(
+        zerodb_client=zerodb_client,
+        hackathon_id=hackathon_id,
+        include_deleted=False,
+    )
+
+    logger.info(f"Returning hackathon details: {hackathon['name']}")
+    return HackathonResponse(**hackathon)
+
+
+@router.patch(
+    "/{hackathon_id}",
+    response_model=HackathonResponse,
+    summary="Update hackathon",
+    description="""
+    Update hackathon details (ORGANIZER role required).
+
+    Only users with the ORGANIZER role for this hackathon can make updates.
+    All fields are optional - only provided fields will be updated.
+
+    **Authentication Required:** Yes (JWT or API Key)
+
+    **Permissions:** ORGANIZER role for this hackathon
+
+    **Path Parameters:**
+    - hackathon_id: UUID of the hackathon to update
+
+    **Request Body:** (all fields optional)
+    - name: Updated hackathon name (3-200 characters)
+    - description: Updated description (max 5000 chars)
+    - start_date: Updated start date in ISO 8601
+    - end_date: Updated end date in ISO 8601
+    - location: Updated location
+    - registration_deadline: Updated deadline in ISO 8601
+    - max_participants: Updated participant limit
+    - website_url: Updated website URL
+    - prizes: Updated prize information
+    - rules: Updated rules
+    - status: Updated status
+
+    **Status Transitions:**
+    Recommended flow: draft → upcoming → active → judging → completed
+
+    **Response:** Updated hackathon details
+
+    **Error Responses:**
+    - 400: Validation error (invalid dates, status, etc.)
+    - 401: Not authenticated
+    - 403: User is not ORGANIZER for this hackathon
+    - 404: Hackathon not found
+    - 500: Database error
+    - 504: Timeout
+    """,
+    responses={
+        200: {
+            "description": "Hackathon updated successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "hackathon_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "name": "AI Hackathon 2025 - Extended",
+                        "status": "active",
+                        "max_participants": 150,
+                        "updated_at": "2025-01-20T15:30:00Z",
+                    }
+                }
+            },
+        },
+        403: {
+            "description": "Not authorized to update this hackathon",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "Forbidden",
+                        "detail": "User does not have ORGANIZER role for this hackathon",
+                        "status_code": 403,
+                    }
+                }
+            },
+        },
+    },
+)
+async def update_hackathon(
+    hackathon_id: str,
+    request: HackathonUpdateRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> HackathonResponse:
+    """
+    Update hackathon endpoint (ORGANIZER only).
+    """
+    user_id = str(current_user.get("id"))
+    logger.info(
+        f"Update hackathon request from user {user_id} for hackathon {hackathon_id}"
+    )
+
+    # Convert request to dict, excluding None values
+    update_data = request.model_dump(exclude_none=True)
+
+    if not update_data:
+        logger.warning(f"Update request with no fields from user {user_id}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields provided for update",
+        )
+
+    # Convert status enum to string if present
+    if "status" in update_data:
+        update_data["status"] = update_data["status"].value
+
+    # Convert URLs to strings
+    if "website_url" in update_data and update_data["website_url"]:
+        update_data["website_url"] = str(update_data["website_url"])
+
+    hackathon = await hackathon_service.update_hackathon(
+        zerodb_client=zerodb_client,
+        hackathon_id=hackathon_id,
+        user_id=user_id,
+        update_data=update_data,
+    )
+
+    logger.info(f"Hackathon {hackathon_id} updated successfully")
+    return HackathonResponse(**hackathon)
+
+
+@router.delete(
+    "/{hackathon_id}",
+    response_model=HackathonDeleteResponse,
+    summary="Delete hackathon",
+    description="""
+    Soft delete a hackathon (ORGANIZER role required).
+
+    This performs a soft delete, marking the hackathon as deleted
+    (is_deleted=True) rather than removing the record. This preserves
+    data integrity and allows for potential recovery.
+
+    **Authentication Required:** Yes (JWT or API Key)
+
+    **Permissions:** ORGANIZER role for this hackathon
+
+    **Path Parameters:**
+    - hackathon_id: UUID of the hackathon to delete
+
+    **Response:** Deletion confirmation
+
+    **Error Responses:**
+    - 401: Not authenticated
+    - 403: User is not ORGANIZER for this hackathon
+    - 404: Hackathon not found or already deleted
+    - 500: Database error
+    - 504: Timeout
+
+    **Note:** Soft-deleted hackathons will not appear in list endpoints
+    or get requests by default. Contact support for recovery.
+    """,
+    responses={
+        200: {
+            "description": "Hackathon deleted successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "success": True,
+                        "hackathon_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "message": "Hackathon successfully deleted",
+                    }
+                }
+            },
+        },
+        403: {
+            "description": "Not authorized to delete this hackathon",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "Forbidden",
+                        "detail": "User does not have ORGANIZER role for this hackathon",
+                        "status_code": 403,
+                    }
+                }
+            },
+        },
+    },
+)
+async def delete_hackathon(
+    hackathon_id: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> HackathonDeleteResponse:
+    """
+    Delete hackathon endpoint (ORGANIZER only, soft delete).
+    """
+    user_id = str(current_user.get("id"))
+    logger.info(
+        f"Delete hackathon request from user {user_id} for hackathon {hackathon_id}"
+    )
+
+    result = await hackathon_service.delete_hackathon(
+        zerodb_client=zerodb_client,
+        hackathon_id=hackathon_id,
+        user_id=user_id,
+    )
+
+    logger.info(f"Hackathon {hackathon_id} deleted successfully")
+    return HackathonDeleteResponse(**result)

--- a/python-api/tests/test_hackathon_endpoints.py
+++ b/python-api/tests/test_hackathon_endpoints.py
@@ -1,0 +1,684 @@
+"""
+Tests for Hackathon API Endpoints
+
+Comprehensive test suite for hackathon CRUD endpoints with authentication,
+authorization, validation, and error handling.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from api.routes.hackathons import router
+from fastapi import status
+from fastapi.testclient import TestClient
+from main import app
+
+
+# Test client
+client = TestClient(app)
+
+
+class TestCreateHackathon:
+    """Test POST /api/v1/hackathons endpoint"""
+
+    def setup_method(self):
+        """Setup test fixtures"""
+        self.valid_payload = {
+            "name": "AI Hackathon 2025",
+            "description": "Build innovative AI applications",
+            "organizer_id": str(uuid.uuid4()),
+            "start_date": (datetime.utcnow() + timedelta(days=30)).isoformat(),
+            "end_date": (datetime.utcnow() + timedelta(days=32)).isoformat(),
+            "location": "San Francisco, CA",
+            "status": "draft",
+        }
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.create_hackathon")
+    def test_create_hackathon_success(
+        self, mock_create, mock_zerodb, mock_auth
+    ):
+        """Should successfully create hackathon"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        self.valid_payload["organizer_id"] = user_id
+
+        hackathon_id = str(uuid.uuid4())
+        mock_create.return_value = {
+            "hackathon_id": hackathon_id,
+            **self.valid_payload,
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+
+        # Act
+        response = client.post(
+            "/api/v1/hackathons",
+            json=self.valid_payload,
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["hackathon_id"] == hackathon_id
+        assert data["name"] == self.valid_payload["name"]
+        assert data["status"] == "draft"
+        mock_create.assert_called_once()
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_create_hackathon_unauthorized(self, mock_auth):
+        """Should return 401 without authentication"""
+        # Act
+        response = client.post("/api/v1/hackathons", json=self.valid_payload)
+
+        # Assert
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_create_hackathon_forbidden_organizer_mismatch(self, mock_auth):
+        """Should return 403 if organizer_id doesn't match authenticated user"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        different_user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        self.valid_payload["organizer_id"] = different_user_id
+
+        # Act
+        response = client.post(
+            "/api/v1/hackathons",
+            json=self.valid_payload,
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "organizer_id must match" in response.json()["detail"]
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_create_hackathon_validation_error_end_before_start(self, mock_auth):
+        """Should return 400 if end_date is before start_date"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        invalid_payload = {
+            **self.valid_payload,
+            "organizer_id": user_id,
+            "start_date": (datetime.utcnow() + timedelta(days=30)).isoformat(),
+            "end_date": (datetime.utcnow() + timedelta(days=25)).isoformat(),  # Before start
+        }
+
+        # Act
+        response = client.post(
+            "/api/v1/hackathons",
+            json=invalid_payload,
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_create_hackathon_validation_error_missing_name(self, mock_auth):
+        """Should return 422 if required field 'name' is missing"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        invalid_payload = {**self.valid_payload}
+        del invalid_payload["name"]
+
+        # Act
+        response = client.post(
+            "/api/v1/hackathons",
+            json=invalid_payload,
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_create_hackathon_validation_error_name_too_short(self, mock_auth):
+        """Should return 422 if name is too short"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        invalid_payload = {
+            **self.valid_payload,
+            "organizer_id": user_id,
+            "name": "AB",  # Less than 3 characters
+        }
+
+        # Act
+        response = client.post(
+            "/api/v1/hackathons",
+            json=invalid_payload,
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.create_hackathon")
+    def test_create_hackathon_with_optional_fields(
+        self, mock_create, mock_zerodb, mock_auth
+    ):
+        """Should successfully create hackathon with all optional fields"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        full_payload = {
+            **self.valid_payload,
+            "organizer_id": user_id,
+            "registration_deadline": (datetime.utcnow() + timedelta(days=20)).isoformat(),
+            "max_participants": 150,
+            "website_url": "https://hackathon2025.com",
+            "prizes": {"first": "$10,000", "second": "$5,000"},
+            "rules": "Standard hackathon rules apply",
+        }
+
+        hackathon_id = str(uuid.uuid4())
+        mock_create.return_value = {
+            "hackathon_id": hackathon_id,
+            **full_payload,
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+
+        # Act
+        response = client.post(
+            "/api/v1/hackathons",
+            json=full_payload,
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["max_participants"] == 150
+        assert data["website_url"] == "https://hackathon2025.com"
+        assert data["prizes"]["first"] == "$10,000"
+
+
+class TestListHackathons:
+    """Test GET /api/v1/hackathons endpoint"""
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.list_hackathons")
+    def test_list_hackathons_success(self, mock_list, mock_zerodb, mock_auth):
+        """Should successfully list hackathons"""
+        # Arrange
+        mock_auth.return_value = {"id": str(uuid.uuid4())}
+        hackathons = [
+            {
+                "hackathon_id": str(uuid.uuid4()),
+                "name": "Hackathon 1",
+                "description": "First hackathon",
+                "organizer_id": str(uuid.uuid4()),
+                "start_date": datetime.utcnow().isoformat(),
+                "end_date": (datetime.utcnow() + timedelta(days=2)).isoformat(),
+                "location": "Virtual",
+                "status": "active",
+                "created_at": datetime.utcnow().isoformat(),
+                "updated_at": datetime.utcnow().isoformat(),
+            },
+            {
+                "hackathon_id": str(uuid.uuid4()),
+                "name": "Hackathon 2",
+                "description": "Second hackathon",
+                "organizer_id": str(uuid.uuid4()),
+                "start_date": datetime.utcnow().isoformat(),
+                "end_date": (datetime.utcnow() + timedelta(days=2)).isoformat(),
+                "location": "San Francisco",
+                "status": "upcoming",
+                "created_at": datetime.utcnow().isoformat(),
+                "updated_at": datetime.utcnow().isoformat(),
+            },
+        ]
+
+        mock_list.return_value = {
+            "hackathons": hackathons,
+            "total": 2,
+            "skip": 0,
+            "limit": 100,
+        }
+
+        # Act
+        response = client.get(
+            "/api/v1/hackathons",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["hackathons"]) == 2
+        assert data["hackathons"][0]["name"] == "Hackathon 1"
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.list_hackathons")
+    def test_list_hackathons_with_pagination(self, mock_list, mock_zerodb, mock_auth):
+        """Should list hackathons with pagination parameters"""
+        # Arrange
+        mock_auth.return_value = {"id": str(uuid.uuid4())}
+        mock_list.return_value = {
+            "hackathons": [],
+            "total": 50,
+            "skip": 10,
+            "limit": 20,
+        }
+
+        # Act
+        response = client.get(
+            "/api/v1/hackathons?skip=10&limit=20",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["skip"] == 10
+        assert data["limit"] == 20
+        mock_list.assert_called_once()
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.list_hackathons")
+    def test_list_hackathons_with_status_filter(self, mock_list, mock_zerodb, mock_auth):
+        """Should filter hackathons by status"""
+        # Arrange
+        mock_auth.return_value = {"id": str(uuid.uuid4())}
+        mock_list.return_value = {
+            "hackathons": [],
+            "total": 10,
+            "skip": 0,
+            "limit": 100,
+        }
+
+        # Act
+        response = client.get(
+            "/api/v1/hackathons?status=active",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        mock_list.assert_called_once()
+        call_kwargs = mock_list.call_args[1]
+        assert call_kwargs["status_filter"] == "active"
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_list_hackathons_unauthorized(self, mock_auth):
+        """Should return 401 without authentication"""
+        # Act
+        response = client.get("/api/v1/hackathons")
+
+        # Assert
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_list_hackathons_validation_error_negative_skip(self, mock_auth):
+        """Should return 422 for negative skip value"""
+        # Arrange
+        mock_auth.return_value = {"id": str(uuid.uuid4())}
+
+        # Act
+        response = client.get(
+            "/api/v1/hackathons?skip=-1",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class TestGetHackathon:
+    """Test GET /api/v1/hackathons/{hackathon_id} endpoint"""
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.get_hackathon")
+    def test_get_hackathon_success(self, mock_get, mock_zerodb, mock_auth):
+        """Should successfully get hackathon details"""
+        # Arrange
+        mock_auth.return_value = {"id": str(uuid.uuid4())}
+        hackathon_id = str(uuid.uuid4())
+        hackathon = {
+            "hackathon_id": hackathon_id,
+            "name": "AI Hackathon 2025",
+            "description": "Build AI apps",
+            "organizer_id": str(uuid.uuid4()),
+            "start_date": datetime.utcnow().isoformat(),
+            "end_date": (datetime.utcnow() + timedelta(days=2)).isoformat(),
+            "location": "Virtual",
+            "status": "active",
+            "max_participants": 100,
+            "website_url": "https://hackathon.com",
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        mock_get.return_value = hackathon
+
+        # Act
+        response = client.get(
+            f"/api/v1/hackathons/{hackathon_id}",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["hackathon_id"] == hackathon_id
+        assert data["name"] == "AI Hackathon 2025"
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.get_hackathon")
+    def test_get_hackathon_not_found(self, mock_get, mock_zerodb, mock_auth):
+        """Should return 404 if hackathon not found"""
+        # Arrange
+        mock_auth.return_value = {"id": str(uuid.uuid4())}
+        from fastapi import HTTPException
+
+        mock_get.side_effect = HTTPException(status_code=404, detail="Hackathon not found")
+
+        # Act
+        response = client.get(
+            f"/api/v1/hackathons/{str(uuid.uuid4())}",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_get_hackathon_unauthorized(self, mock_auth):
+        """Should return 401 without authentication"""
+        # Act
+        response = client.get(f"/api/v1/hackathons/{str(uuid.uuid4())}")
+
+        # Assert
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestUpdateHackathon:
+    """Test PATCH /api/v1/hackathons/{hackathon_id} endpoint"""
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.update_hackathon")
+    def test_update_hackathon_success(self, mock_update, mock_zerodb, mock_auth):
+        """Should successfully update hackathon (ORGANIZER)"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        hackathon_id = str(uuid.uuid4())
+
+        update_payload = {
+            "name": "Updated Hackathon Name",
+            "status": "active",
+            "max_participants": 200,
+        }
+
+        updated_hackathon = {
+            "hackathon_id": hackathon_id,
+            "name": "Updated Hackathon Name",
+            "description": "Original description",
+            "organizer_id": user_id,
+            "start_date": datetime.utcnow().isoformat(),
+            "end_date": (datetime.utcnow() + timedelta(days=2)).isoformat(),
+            "location": "Virtual",
+            "status": "active",
+            "max_participants": 200,
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        mock_update.return_value = updated_hackathon
+
+        # Act
+        response = client.patch(
+            f"/api/v1/hackathons/{hackathon_id}",
+            json=update_payload,
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["name"] == "Updated Hackathon Name"
+        assert data["status"] == "active"
+        assert data["max_participants"] == 200
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.update_hackathon")
+    def test_update_hackathon_forbidden_not_organizer(
+        self, mock_update, mock_zerodb, mock_auth
+    ):
+        """Should return 403 if user is not ORGANIZER"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        from fastapi import HTTPException
+
+        mock_update.side_effect = HTTPException(
+            status_code=403, detail="User does not have ORGANIZER role"
+        )
+
+        # Act
+        response = client.patch(
+            f"/api/v1/hackathons/{str(uuid.uuid4())}",
+            json={"name": "Updated Name"},
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_update_hackathon_validation_error_no_fields(self, mock_auth):
+        """Should return 400 if no fields provided for update"""
+        # Arrange
+        mock_auth.return_value = {"id": str(uuid.uuid4())}
+
+        # Act
+        response = client.patch(
+            f"/api/v1/hackathons/{str(uuid.uuid4())}",
+            json={},
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_update_hackathon_unauthorized(self, mock_auth):
+        """Should return 401 without authentication"""
+        # Act
+        response = client.patch(
+            f"/api/v1/hackathons/{str(uuid.uuid4())}",
+            json={"name": "Updated"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestDeleteHackathon:
+    """Test DELETE /api/v1/hackathons/{hackathon_id} endpoint"""
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.delete_hackathon")
+    def test_delete_hackathon_success(self, mock_delete, mock_zerodb, mock_auth):
+        """Should successfully delete hackathon (ORGANIZER, soft delete)"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        hackathon_id = str(uuid.uuid4())
+
+        mock_delete.return_value = {
+            "success": True,
+            "hackathon_id": hackathon_id,
+            "message": "Hackathon successfully deleted",
+        }
+
+        # Act
+        response = client.delete(
+            f"/api/v1/hackathons/{hackathon_id}",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["success"] is True
+        assert data["hackathon_id"] == hackathon_id
+        assert "successfully deleted" in data["message"]
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.delete_hackathon")
+    def test_delete_hackathon_forbidden_not_organizer(
+        self, mock_delete, mock_zerodb, mock_auth
+    ):
+        """Should return 403 if user is not ORGANIZER"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        from fastapi import HTTPException
+
+        mock_delete.side_effect = HTTPException(
+            status_code=403, detail="User does not have ORGANIZER role"
+        )
+
+        # Act
+        response = client.delete(
+            f"/api/v1/hackathons/{str(uuid.uuid4())}",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.delete_hackathon")
+    def test_delete_hackathon_not_found(self, mock_delete, mock_zerodb, mock_auth):
+        """Should return 404 if hackathon not found"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        from fastapi import HTTPException
+
+        mock_delete.side_effect = HTTPException(
+            status_code=404, detail="Hackathon not found"
+        )
+
+        # Act
+        response = client.delete(
+            f"/api/v1/hackathons/{str(uuid.uuid4())}",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @patch("api.routes.hackathons.get_current_user")
+    def test_delete_hackathon_unauthorized(self, mock_auth):
+        """Should return 401 without authentication"""
+        # Act
+        response = client.delete(f"/api/v1/hackathons/{str(uuid.uuid4())}")
+
+        # Assert
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestHackathonEndpointsIntegration:
+    """Integration tests for hackathon endpoints workflow"""
+
+    @patch("api.routes.hackathons.get_current_user")
+    @patch("api.routes.hackathons.get_zerodb_client")
+    @patch("services.hackathon_service.create_hackathon")
+    @patch("services.hackathon_service.get_hackathon")
+    @patch("services.hackathon_service.update_hackathon")
+    @patch("services.hackathon_service.delete_hackathon")
+    def test_full_hackathon_lifecycle(
+        self,
+        mock_delete,
+        mock_update,
+        mock_get,
+        mock_create,
+        mock_zerodb,
+        mock_auth,
+    ):
+        """Should test complete hackathon lifecycle: create → get → update → delete"""
+        # Arrange
+        user_id = str(uuid.uuid4())
+        mock_auth.return_value = {"id": user_id}
+        hackathon_id = str(uuid.uuid4())
+
+        # Step 1: Create
+        create_payload = {
+            "name": "Test Hackathon",
+            "description": "Test description",
+            "organizer_id": user_id,
+            "start_date": (datetime.utcnow() + timedelta(days=30)).isoformat(),
+            "end_date": (datetime.utcnow() + timedelta(days=32)).isoformat(),
+            "location": "Virtual",
+            "status": "draft",
+        }
+
+        created_hackathon = {
+            "hackathon_id": hackathon_id,
+            **create_payload,
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        mock_create.return_value = created_hackathon
+
+        create_response = client.post(
+            "/api/v1/hackathons",
+            json=create_payload,
+            headers={"Authorization": "Bearer fake-token"},
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+
+        # Step 2: Get
+        mock_get.return_value = created_hackathon
+        get_response = client.get(
+            f"/api/v1/hackathons/{hackathon_id}",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+        assert get_response.status_code == status.HTTP_200_OK
+
+        # Step 3: Update
+        updated_hackathon = {**created_hackathon, "status": "active"}
+        mock_update.return_value = updated_hackathon
+        update_response = client.patch(
+            f"/api/v1/hackathons/{hackathon_id}",
+            json={"status": "active"},
+            headers={"Authorization": "Bearer fake-token"},
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+
+        # Step 4: Delete
+        mock_delete.return_value = {
+            "success": True,
+            "hackathon_id": hackathon_id,
+            "message": "Hackathon successfully deleted",
+        }
+        delete_response = client.delete(
+            f"/api/v1/hackathons/{hackathon_id}",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+        assert delete_response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Closes #17

## Summary
- POST /v1/hackathons - Create hackathon
- GET /v1/hackathons - List hackathons with pagination
- GET /v1/hackathons/{id} - Get hackathon details
- PATCH /v1/hackathons/{id} - Update hackathon (organizer only)
- DELETE /v1/hackathons/{id} - Delete hackathon (organizer only)
- Comprehensive endpoint tests with mocked dependencies

## Test Plan
- Run pytest tests/test_hackathon_endpoints.py
- Verify all endpoints respond correctly
- Verify authorization checks work

## Risk/Rollback
- Low risk - new endpoints only
- Rollback: Remove hackathons.py routes file