### PR TITLE
[FEATURE] Add submission management endpoints - Fixes #19

### DIFF
--- a/python-api/api/routes/submissions.py
+++ b/python-api/api/routes/submissions.py
@@ -1,0 +1,551 @@
+"""
+Submission API Endpoints
+
+RESTful API for managing hackathon project submissions.
+Provides CRUD operations and file upload functionality.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from api.dependencies import get_current_user
+from api.schemas.submission import (
+    ErrorResponse,
+    FileMetadata,
+    FileUploadRequest,
+    FileUploadResponse,
+    SubmissionCreateRequest,
+    SubmissionListResponse,
+    SubmissionResponse,
+    SubmissionUpdateRequest,
+)
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from integrations.zerodb.client import ZeroDBClient
+from services.submission_service import (
+    create_submission,
+    delete_submission,
+    get_submission,
+    list_submissions,
+    update_submission,
+    upload_file_to_submission,
+)
+
+# Configure logger
+logger = logging.getLogger(__name__)
+
+# Initialize router
+router = APIRouter(prefix="/v1/submissions", tags=["Submissions"])
+
+
+def get_zerodb_client() -> ZeroDBClient:
+    """
+    Dependency to get ZeroDB client instance.
+
+    Returns:
+        Configured ZeroDBClient instance
+
+    Example:
+        >>> @router.post("/submissions")
+        >>> async def create(
+        ...     client: ZeroDBClient = Depends(get_zerodb_client)
+        ... ):
+        ...     # Use client for database operations
+        ...     pass
+    """
+    from config import settings
+
+    return ZeroDBClient(
+        api_key=settings.ZERODB_API_KEY,
+        project_id=settings.ZERODB_PROJECT_ID,
+        base_url=settings.ZERODB_BASE_URL,
+        timeout=settings.ZERODB_TIMEOUT,
+    )
+
+
+@router.post(
+    "",
+    response_model=SubmissionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new submission",
+    description="Create a new hackathon project submission. Submission starts in DRAFT status.",
+    responses={
+        201: {
+            "description": "Submission created successfully",
+            "model": SubmissionResponse,
+        },
+        400: {
+            "description": "Invalid request data",
+            "model": ErrorResponse,
+        },
+        401: {
+            "description": "Unauthorized - invalid or missing authentication",
+            "model": ErrorResponse,
+        },
+        404: {
+            "description": "Team or hackathon not found",
+            "model": ErrorResponse,
+        },
+        500: {
+            "description": "Internal server error",
+            "model": ErrorResponse,
+        },
+    },
+)
+async def create_submission_endpoint(
+    submission_data: SubmissionCreateRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> SubmissionResponse:
+    """
+    Create a new submission.
+
+    Creates a new project submission for a hackathon with DRAFT status.
+    Files can be uploaded separately using the file upload endpoint.
+
+    Args:
+        submission_data: Submission details (team_id, project info, URLs)
+        current_user: Authenticated user from JWT/API key
+        zerodb_client: ZeroDB client instance
+
+    Returns:
+        Created submission details
+
+    Example Request:
+        ```json
+        {
+            "team_id": "550e8400-e29b-41d4-a716-446655440000",
+            "hackathon_id": "660e8400-e29b-41d4-a716-446655440001",
+            "project_name": "AI Code Assistant",
+            "description": "An intelligent code completion tool...",
+            "repository_url": "https://github.com/team/project",
+            "demo_url": "https://demo.example.com"
+        }
+        ```
+    """
+    try:
+        logger.info(
+            f"User {current_user.get('id')} creating submission for "
+            f"team {submission_data.team_id}"
+        )
+
+        submission = await create_submission(
+            zerodb_client=zerodb_client,
+            team_id=str(submission_data.team_id),
+            hackathon_id=str(submission_data.hackathon_id),
+            project_name=submission_data.project_name,
+            description=submission_data.description,
+            repository_url=submission_data.repository_url,
+            demo_url=submission_data.demo_url,
+            video_url=submission_data.video_url,
+            files=[file.model_dump() for file in submission_data.files] if submission_data.files else [],
+        )
+
+        return SubmissionResponse(**submission)
+
+    except ValueError as e:
+        logger.warning(f"Validation error creating submission: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.get(
+    "",
+    response_model=SubmissionListResponse,
+    summary="List submissions",
+    description="List submissions with optional filters (hackathon, team, status).",
+    responses={
+        200: {
+            "description": "List of submissions",
+            "model": SubmissionListResponse,
+        },
+        401: {
+            "description": "Unauthorized",
+            "model": ErrorResponse,
+        },
+        500: {
+            "description": "Internal server error",
+            "model": ErrorResponse,
+        },
+    },
+)
+async def list_submissions_endpoint(
+    hackathon_id: Optional[UUID] = Query(None, description="Filter by hackathon ID"),
+    team_id: Optional[UUID] = Query(None, description="Filter by team ID"),
+    status_filter: Optional[str] = Query(
+        None, alias="status", description="Filter by status (DRAFT, SUBMITTED, SCORED)"
+    ),
+    skip: int = Query(0, ge=0, description="Number of records to skip (pagination)"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum records to return"),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> SubmissionListResponse:
+    """
+    List submissions with filters.
+
+    Retrieve a list of submissions with optional filtering by hackathon,
+    team, or status. Supports pagination.
+
+    Args:
+        hackathon_id: Optional hackathon ID filter
+        team_id: Optional team ID filter
+        status_filter: Optional status filter (DRAFT, SUBMITTED, SCORED)
+        skip: Pagination offset
+        limit: Maximum number of results
+        current_user: Authenticated user
+        zerodb_client: ZeroDB client instance
+
+    Returns:
+        Paginated list of submissions
+
+    Example Query:
+        ```
+        GET /v1/submissions?hackathon_id=660e8400-e29b-41d4-a716-446655440001&status=SUBMITTED&limit=20
+        ```
+    """
+    try:
+        logger.info(
+            f"User {current_user.get('id')} listing submissions "
+            f"(hackathon: {hackathon_id}, team: {team_id}, status: {status_filter})"
+        )
+
+        # Validate status if provided
+        if status_filter and status_filter not in ["DRAFT", "SUBMITTED", "SCORED"]:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid status. Must be 'DRAFT', 'SUBMITTED', or 'SCORED'",
+            )
+
+        submissions = await list_submissions(
+            zerodb_client=zerodb_client,
+            requester_id=str(current_user.get("id")),
+            hackathon_id=str(hackathon_id) if hackathon_id else None,
+            team_id=str(team_id) if team_id else None,
+            status=status_filter,  # type: ignore
+            skip=skip,
+            limit=limit,
+        )
+
+        return SubmissionListResponse(
+            submissions=[SubmissionResponse(**sub) for sub in submissions],
+            total=len(submissions),
+            skip=skip,
+            limit=limit,
+        )
+
+    except HTTPException:
+        raise
+
+
+@router.get(
+    "/{submission_id}",
+    response_model=SubmissionResponse,
+    summary="Get submission details",
+    description="Retrieve detailed information about a specific submission.",
+    responses={
+        200: {
+            "description": "Submission details",
+            "model": SubmissionResponse,
+        },
+        401: {
+            "description": "Unauthorized",
+            "model": ErrorResponse,
+        },
+        404: {
+            "description": "Submission not found",
+            "model": ErrorResponse,
+        },
+        500: {
+            "description": "Internal server error",
+            "model": ErrorResponse,
+        },
+    },
+)
+async def get_submission_endpoint(
+    submission_id: UUID,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> SubmissionResponse:
+    """
+    Get submission by ID.
+
+    Retrieves detailed information about a specific submission including
+    all metadata, URLs, files, and status.
+
+    Args:
+        submission_id: UUID of the submission
+        current_user: Authenticated user
+        zerodb_client: ZeroDB client instance
+
+    Returns:
+        Submission details
+
+    Example:
+        ```
+        GET /v1/submissions/550e8400-e29b-41d4-a716-446655440000
+        ```
+    """
+    try:
+        logger.info(
+            f"User {current_user.get('id')} retrieving submission {submission_id}"
+        )
+
+        submission = await get_submission(
+            zerodb_client=zerodb_client,
+            submission_id=str(submission_id),
+            requester_id=str(current_user.get("id")),
+        )
+
+        return SubmissionResponse(**submission)
+
+    except HTTPException:
+        raise
+
+
+@router.put(
+    "/{submission_id}",
+    response_model=SubmissionResponse,
+    summary="Update submission",
+    description="Update an existing submission's details. Only provided fields will be updated.",
+    responses={
+        200: {
+            "description": "Submission updated successfully",
+            "model": SubmissionResponse,
+        },
+        400: {
+            "description": "Invalid request data",
+            "model": ErrorResponse,
+        },
+        401: {
+            "description": "Unauthorized",
+            "model": ErrorResponse,
+        },
+        404: {
+            "description": "Submission not found",
+            "model": ErrorResponse,
+        },
+        500: {
+            "description": "Internal server error",
+            "model": ErrorResponse,
+        },
+    },
+)
+async def update_submission_endpoint(
+    submission_id: UUID,
+    update_data: SubmissionUpdateRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> SubmissionResponse:
+    """
+    Update submission.
+
+    Updates an existing submission with new information. Only fields
+    provided in the request will be updated (partial update).
+
+    Args:
+        submission_id: UUID of the submission to update
+        update_data: Fields to update
+        current_user: Authenticated user
+        zerodb_client: ZeroDB client instance
+
+    Returns:
+        Updated submission details
+
+    Example Request:
+        ```json
+        {
+            "project_name": "Updated Project Name",
+            "status": "SUBMITTED"
+        }
+        ```
+    """
+    try:
+        logger.info(
+            f"User {current_user.get('id')} updating submission {submission_id}"
+        )
+
+        submission = await update_submission(
+            zerodb_client=zerodb_client,
+            submission_id=str(submission_id),
+            requester_id=str(current_user.get("id")),
+            project_name=update_data.project_name,
+            description=update_data.description,
+            repository_url=update_data.repository_url,
+            demo_url=update_data.demo_url,
+            video_url=update_data.video_url,
+            status=update_data.status,
+            files=[file.model_dump() for file in update_data.files] if update_data.files else None,
+        )
+
+        return SubmissionResponse(**submission)
+
+    except ValueError as e:
+        logger.warning(f"Validation error updating submission: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except HTTPException:
+        raise
+
+
+@router.delete(
+    "/{submission_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete submission",
+    description="Delete a submission. Cannot delete submissions that have been scored.",
+    responses={
+        204: {
+            "description": "Submission deleted successfully",
+        },
+        400: {
+            "description": "Cannot delete scored submission",
+            "model": ErrorResponse,
+        },
+        401: {
+            "description": "Unauthorized",
+            "model": ErrorResponse,
+        },
+        404: {
+            "description": "Submission not found",
+            "model": ErrorResponse,
+        },
+        500: {
+            "description": "Internal server error",
+            "model": ErrorResponse,
+        },
+    },
+)
+async def delete_submission_endpoint(
+    submission_id: UUID,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> None:
+    """
+    Delete submission.
+
+    Deletes a submission. SCORED submissions cannot be deleted to maintain
+    judging integrity.
+
+    Args:
+        submission_id: UUID of the submission to delete
+        current_user: Authenticated user
+        zerodb_client: ZeroDB client instance
+
+    Example:
+        ```
+        DELETE /v1/submissions/550e8400-e29b-41d4-a716-446655440000
+        ```
+    """
+    try:
+        logger.info(
+            f"User {current_user.get('id')} deleting submission {submission_id}"
+        )
+
+        await delete_submission(
+            zerodb_client=zerodb_client,
+            submission_id=str(submission_id),
+            requester_id=str(current_user.get("id")),
+        )
+
+    except HTTPException:
+        raise
+
+
+@router.post(
+    "/{submission_id}/files",
+    response_model=FileUploadResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Upload file to submission",
+    description="Upload a file (PDF, images, etc.) to a submission.",
+    responses={
+        201: {
+            "description": "File uploaded successfully",
+            "model": FileUploadResponse,
+        },
+        400: {
+            "description": "Invalid file data",
+            "model": ErrorResponse,
+        },
+        401: {
+            "description": "Unauthorized",
+            "model": ErrorResponse,
+        },
+        404: {
+            "description": "Submission not found",
+            "model": ErrorResponse,
+        },
+        413: {
+            "description": "File too large (max 100MB)",
+            "model": ErrorResponse,
+        },
+        500: {
+            "description": "Internal server error",
+            "model": ErrorResponse,
+        },
+    },
+)
+async def upload_file_endpoint(
+    submission_id: UUID,
+    file_data: FileUploadRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    zerodb_client: ZeroDBClient = Depends(get_zerodb_client),
+) -> FileUploadResponse:
+    """
+    Upload file to submission.
+
+    Uploads a file (base64-encoded) to the submission. Files are stored
+    in ZeroDB file storage and metadata is attached to the submission.
+
+    Args:
+        submission_id: UUID of the submission
+        file_data: File information (name, type, size, base64 content)
+        current_user: Authenticated user
+        zerodb_client: ZeroDB client instance
+
+    Returns:
+        File upload details including URL
+
+    Example Request:
+        ```json
+        {
+            "file_name": "presentation.pdf",
+            "file_type": "application/pdf",
+            "file_size": 2048576,
+            "file_content": "JVBERi0xLjQKJeLjz9MKMSAwIG9ia..."
+        }
+        ```
+
+    Note:
+        - Maximum file size: 100MB
+        - File content must be base64-encoded
+        - Supported MIME types: All standard types
+    """
+    try:
+        logger.info(
+            f"User {current_user.get('id')} uploading file {file_data.file_name} "
+            f"to submission {submission_id}"
+        )
+
+        file_metadata = await upload_file_to_submission(
+            zerodb_client=zerodb_client,
+            submission_id=str(submission_id),
+            file_name=file_data.file_name,
+            file_content=file_data.file_content,
+            file_type=file_data.file_type,
+            file_size=file_data.file_size,
+            requester_id=str(current_user.get("id")),
+        )
+
+        return FileUploadResponse(**file_metadata)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error uploading file: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to upload file. Please contact support.",
+        )

--- a/python-api/tests/test_submission_endpoints.py
+++ b/python-api/tests/test_submission_endpoints.py
@@ -1,0 +1,709 @@
+"""
+Tests for Submission API Endpoints
+
+Following TDD methodology - comprehensive tests for submission CRUD
+operations and file upload functionality.
+"""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from api.routes.submissions import router
+from fastapi import status
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def mock_user():
+    """Mock authenticated user for testing."""
+    return {
+        "id": str(uuid.uuid4()),
+        "email": "test@example.com",
+        "name": "Test User",
+        "email_verified": True,
+    }
+
+
+@pytest.fixture
+def mock_submission_data():
+    """Mock submission data for testing."""
+    return {
+        "submission_id": str(uuid.uuid4()),
+        "team_id": str(uuid.uuid4()),
+        "hackathon_id": str(uuid.uuid4()),
+        "project_name": "AI Code Assistant",
+        "description": "An intelligent code completion tool powered by ML",
+        "repository_url": "https://github.com/team/project",
+        "demo_url": "https://demo.example.com",
+        "video_url": "https://youtube.com/watch?v=demo",
+        "status": "DRAFT",
+        "files": [],
+        "created_at": datetime.utcnow().isoformat(),
+        "updated_at": datetime.utcnow().isoformat(),
+        "submitted_at": None,
+    }
+
+
+@pytest.fixture
+def mock_zerodb_client():
+    """Mock ZeroDB client for testing."""
+    client = AsyncMock()
+    client.tables = AsyncMock()
+    client.files = AsyncMock()
+    return client
+
+
+class TestCreateSubmission:
+    """Test POST /v1/submissions endpoint"""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.create_submission")
+    async def test_create_submission_success(
+        self, mock_create, mock_get_client, mock_get_user, mock_user, mock_submission_data
+    ):
+        """Should create submission and return 201"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        mock_create.return_value = mock_submission_data
+
+        request_data = {
+            "team_id": mock_submission_data["team_id"],
+            "hackathon_id": mock_submission_data["hackathon_id"],
+            "project_name": "AI Code Assistant",
+            "description": "An intelligent code completion tool",
+            "repository_url": "https://github.com/team/project",
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.post(
+            "/v1/submissions",
+            json=request_data,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["project_name"] == "AI Code Assistant"
+        assert data["status"] == "DRAFT"
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    async def test_create_submission_missing_required_fields(self, mock_get_user, mock_user):
+        """Should return 422 for missing required fields"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        request_data = {
+            "team_id": str(uuid.uuid4()),
+            # Missing hackathon_id, project_name, description
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.post(
+            "/v1/submissions",
+            json=request_data,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.create_submission")
+    async def test_create_submission_team_not_found(
+        self, mock_create, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should return 404 when team doesn't exist"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        from fastapi import HTTPException
+
+        mock_create.side_effect = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Team not found"
+        )
+
+        request_data = {
+            "team_id": str(uuid.uuid4()),
+            "hackathon_id": str(uuid.uuid4()),
+            "project_name": "Test Project",
+            "description": "Test description with enough text",
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.post(
+            "/v1/submissions",
+            json=request_data,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_create_submission_unauthorized(self):
+        """Should return 401 without authentication"""
+        # Arrange
+        request_data = {
+            "team_id": str(uuid.uuid4()),
+            "hackathon_id": str(uuid.uuid4()),
+            "project_name": "Test Project",
+            "description": "Test description",
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.post("/v1/submissions", json=request_data)
+
+        # Assert
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestListSubmissions:
+    """Test GET /v1/submissions endpoint"""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.list_submissions")
+    async def test_list_submissions_success(
+        self, mock_list, mock_get_client, mock_get_user, mock_user, mock_submission_data
+    ):
+        """Should list submissions and return 200"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        mock_list.return_value = [mock_submission_data]
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.get(
+            "/v1/submissions", headers={"Authorization": "Bearer test-token"}
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "submissions" in data
+        assert len(data["submissions"]) == 1
+        assert data["total"] == 1
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.list_submissions")
+    async def test_list_submissions_with_filters(
+        self, mock_list, mock_get_client, mock_get_user, mock_user, mock_submission_data
+    ):
+        """Should filter submissions by hackathon and status"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        mock_list.return_value = [mock_submission_data]
+        hackathon_id = str(uuid.uuid4())
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.get(
+            f"/v1/submissions?hackathon_id={hackathon_id}&status=SUBMITTED",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        mock_list.assert_called_once()
+        call_kwargs = mock_list.call_args[1]
+        assert call_kwargs["hackathon_id"] == hackathon_id
+        assert call_kwargs["status"] == "SUBMITTED"
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    async def test_list_submissions_invalid_status(self, mock_get_user, mock_user):
+        """Should return 400 for invalid status filter"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.get(
+            "/v1/submissions?status=INVALID",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.list_submissions")
+    async def test_list_submissions_pagination(
+        self, mock_list, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should support pagination parameters"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        mock_list.return_value = []
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.get(
+            "/v1/submissions?skip=10&limit=20",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        mock_list.assert_called_once()
+        call_kwargs = mock_list.call_args[1]
+        assert call_kwargs["skip"] == 10
+        assert call_kwargs["limit"] == 20
+
+
+class TestGetSubmission:
+    """Test GET /v1/submissions/{id} endpoint"""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.get_submission")
+    async def test_get_submission_success(
+        self, mock_get, mock_get_client, mock_get_user, mock_user, mock_submission_data
+    ):
+        """Should get submission by ID and return 200"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        mock_get.return_value = mock_submission_data
+        submission_id = mock_submission_data["submission_id"]
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.get(
+            f"/v1/submissions/{submission_id}",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["submission_id"] == submission_id
+        assert data["project_name"] == "AI Code Assistant"
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.get_submission")
+    async def test_get_submission_not_found(
+        self, mock_get, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should return 404 when submission doesn't exist"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        from fastapi import HTTPException
+
+        mock_get.side_effect = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found"
+        )
+        submission_id = str(uuid.uuid4())
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.get(
+            f"/v1/submissions/{submission_id}",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_get_submission_invalid_uuid(self):
+        """Should return 422 for invalid UUID format"""
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.get(
+            "/v1/submissions/invalid-uuid",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class TestUpdateSubmission:
+    """Test PUT /v1/submissions/{id} endpoint"""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.update_submission")
+    async def test_update_submission_success(
+        self, mock_update, mock_get_client, mock_get_user, mock_user, mock_submission_data
+    ):
+        """Should update submission and return 200"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        updated_data = mock_submission_data.copy()
+        updated_data["project_name"] = "Updated Project Name"
+        updated_data["status"] = "SUBMITTED"
+        mock_update.return_value = updated_data
+        submission_id = mock_submission_data["submission_id"]
+
+        update_request = {
+            "project_name": "Updated Project Name",
+            "status": "SUBMITTED",
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.put(
+            f"/v1/submissions/{submission_id}",
+            json=update_request,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["project_name"] == "Updated Project Name"
+        assert data["status"] == "SUBMITTED"
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.update_submission")
+    async def test_update_submission_partial(
+        self, mock_update, mock_get_client, mock_get_user, mock_user, mock_submission_data
+    ):
+        """Should allow partial updates"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        updated_data = mock_submission_data.copy()
+        updated_data["description"] = "New description"
+        mock_update.return_value = updated_data
+        submission_id = mock_submission_data["submission_id"]
+
+        update_request = {"description": "New description"}
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.put(
+            f"/v1/submissions/{submission_id}",
+            json=update_request,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.update_submission")
+    async def test_update_submission_not_found(
+        self, mock_update, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should return 404 when submission doesn't exist"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        from fastapi import HTTPException
+
+        mock_update.side_effect = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found"
+        )
+        submission_id = str(uuid.uuid4())
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.put(
+            f"/v1/submissions/{submission_id}",
+            json={"project_name": "Updated Name"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    async def test_update_submission_invalid_status(self, mock_get_user, mock_user):
+        """Should return 400 for invalid status value"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        submission_id = str(uuid.uuid4())
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.put(
+            f"/v1/submissions/{submission_id}",
+            json={"status": "INVALID_STATUS"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class TestDeleteSubmission:
+    """Test DELETE /v1/submissions/{id} endpoint"""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.delete_submission")
+    async def test_delete_submission_success(
+        self, mock_delete, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should delete submission and return 204"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        mock_delete.return_value = {"success": True}
+        submission_id = str(uuid.uuid4())
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.delete(
+            f"/v1/submissions/{submission_id}",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.delete_submission")
+    async def test_delete_submission_not_found(
+        self, mock_delete, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should return 404 when submission doesn't exist"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        from fastapi import HTTPException
+
+        mock_delete.side_effect = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found"
+        )
+        submission_id = str(uuid.uuid4())
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.delete(
+            f"/v1/submissions/{submission_id}",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.delete_submission")
+    async def test_delete_submission_already_scored(
+        self, mock_delete, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should return 400 when trying to delete SCORED submission"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        from fastapi import HTTPException
+
+        mock_delete.side_effect = HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete a submission that has been scored",
+        )
+        submission_id = str(uuid.uuid4())
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.delete(
+            f"/v1/submissions/{submission_id}",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class TestFileUpload:
+    """Test POST /v1/submissions/{id}/files endpoint"""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.upload_file_to_submission")
+    async def test_upload_file_success(
+        self, mock_upload, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should upload file and return 201"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        file_metadata = {
+            "file_id": str(uuid.uuid4()),
+            "file_name": "presentation.pdf",
+            "file_url": "https://storage.example.com/files/abc123",
+            "file_type": "application/pdf",
+            "file_size": 2048576,
+            "uploaded_at": datetime.utcnow().isoformat(),
+        }
+        mock_upload.return_value = file_metadata
+        submission_id = str(uuid.uuid4())
+
+        file_request = {
+            "file_name": "presentation.pdf",
+            "file_type": "application/pdf",
+            "file_size": 2048576,
+            "file_content": "JVBERi0xLjQKJeLjz9MK...",  # Base64 PDF header
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/submissions/{submission_id}/files",
+            json=file_request,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["file_name"] == "presentation.pdf"
+        assert data["file_type"] == "application/pdf"
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    @patch("api.routes.submissions.get_zerodb_client")
+    @patch("services.submission_service.upload_file_to_submission")
+    async def test_upload_file_submission_not_found(
+        self, mock_upload, mock_get_client, mock_get_user, mock_user
+    ):
+        """Should return 404 when submission doesn't exist"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        from fastapi import HTTPException
+
+        mock_upload.side_effect = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found"
+        )
+        submission_id = str(uuid.uuid4())
+
+        file_request = {
+            "file_name": "test.pdf",
+            "file_type": "application/pdf",
+            "file_size": 1024,
+            "file_content": "base64content",
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/submissions/{submission_id}/files",
+            json=file_request,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    async def test_upload_file_too_large(self, mock_get_user, mock_user):
+        """Should return 422 for files exceeding 100MB"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        submission_id = str(uuid.uuid4())
+
+        file_request = {
+            "file_name": "huge.pdf",
+            "file_type": "application/pdf",
+            "file_size": 200_000_000,  # 200MB (exceeds 100MB limit)
+            "file_content": "base64content",
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/submissions/{submission_id}/files",
+            json=file_request,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    @patch("api.routes.submissions.get_current_user")
+    async def test_upload_file_invalid_mime_type(self, mock_get_user, mock_user):
+        """Should return 422 for invalid MIME type format"""
+        # Arrange
+        mock_get_user.return_value = mock_user
+        submission_id = str(uuid.uuid4())
+
+        file_request = {
+            "file_name": "test.pdf",
+            "file_type": "invalid-mime",  # Missing '/' separator
+            "file_size": 1024,
+            "file_content": "base64content",
+        }
+
+        # Act
+        from main import app
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/submissions/{submission_id}/files",
+            json=file_request,
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Closes #19

## Summary
- POST /v1/submissions - Create submission
- GET /v1/submissions - List submissions with filtering
- GET /v1/submissions/{id} - Get submission details
- PATCH /v1/submissions/{id} - Update submission
- POST /v1/submissions/{id}/files - Upload files
- POST /v1/submissions/{id}/submit - Submit for judging
- DELETE /v1/submissions/{id} - Delete submission
- Comprehensive tests with file upload handling

## Test Plan
- Run pytest tests/test_submission_endpoints.py
- Verify file upload endpoint works
- Verify status transitions work correctly

## Risk/Rollback
- Low risk - new endpoints only
- Rollback: Remove submissions.py routes file