### PR TITLE
Implement Prizes API for Hackathon Prize Management

### DIFF
--- a/python-api/api/routes/prizes.py
+++ b/python-api/api/routes/prizes.py
@@ -1,0 +1,292 @@
+"""
+Prize API Routes
+
+RESTful API endpoints for hackathon prize CRUD operations.
+"""
+
+import logging
+from typing import Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from api.dependencies import get_current_user, get_zerodb_client
+from api.schemas.prize import (
+    ErrorResponse,
+    PrizeCreateRequest,
+    PrizeListResponse,
+    PrizeResponse,
+    PrizeUpdateRequest,
+)
+from integrations.zerodb.client import ZeroDBClient
+from services.authorization import check_organizer
+from services.prize_service import PrizeService
+
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(
+    prefix="/api/v1/hackathons",
+    tags=["Prizes"],
+    responses={
+        401: {"model": ErrorResponse, "description": "Unauthorized"},
+        403: {"model": ErrorResponse, "description": "Forbidden"},
+        404: {"model": ErrorResponse, "description": "Not Found"},
+        500: {"model": ErrorResponse, "description": "Internal Server Error"},
+    },
+)
+
+
+@router.post(
+    "/{hackathon_id}/prizes",
+    response_model=PrizeResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a prize",
+    description="""
+    Create a new prize for a hackathon.
+
+    **Authentication Required:** Yes
+    **Permissions:** ORGANIZER role for the hackathon
+
+    Prizes can be hackathon-level (overall winners) or track-specific.
+    Rank must be unique within the same scope (hackathon or track).
+    """,
+)
+async def create_prize(
+    hackathon_id: str,
+    request: PrizeCreateRequest,
+    current_user: Dict = Depends(get_current_user),
+    zerodb: ZeroDBClient = Depends(get_zerodb_client),
+) -> PrizeResponse:
+    """
+    Create a new prize.
+
+    Args:
+        hackathon_id: UUID of the hackathon
+        request: Prize creation data
+        current_user: Authenticated user
+        zerodb: ZeroDB client
+
+    Returns:
+        Created prize data
+
+    Raises:
+        403: If user is not an ORGANIZER
+        404: If hackathon or track not found
+        409: If rank already exists for the same scope
+    """
+    # Verify user is organizer
+    await check_organizer(hackathon_id, current_user["id"], zerodb)
+
+    logger.info(
+        f"User {current_user['id']} creating prize '{request.title}' "
+        f"for hackathon {hackathon_id}"
+    )
+
+    service = PrizeService(zerodb)
+    prize = await service.create_prize(
+        hackathon_id=hackathon_id,
+        title=request.title,
+        description=request.description,
+        amount=request.amount,
+        currency=request.currency,
+        rank=request.rank,
+        track_id=request.track_id,
+        sponsor_name=request.sponsor_name,
+        display_order=request.display_order,
+    )
+
+    return PrizeResponse(**prize)
+
+
+@router.get(
+    "/{hackathon_id}/prizes",
+    response_model=PrizeListResponse,
+    summary="List prizes",
+    description="""
+    List all prizes for a hackathon.
+
+    **Authentication Required:** No (public endpoint)
+    **Permissions:** Any user can view prizes
+
+    Supports filtering by track_id and rank.
+    Results are sorted by display_order and rank.
+    """,
+)
+async def list_prizes(
+    hackathon_id: str,
+    track_id: Optional[str] = Query(None, description="Filter by track ID"),
+    rank: Optional[int] = Query(None, ge=1, le=100, description="Filter by rank"),
+    zerodb: ZeroDBClient = Depends(get_zerodb_client),
+) -> PrizeListResponse:
+    """
+    List all prizes for a hackathon.
+
+    Args:
+        hackathon_id: UUID of the hackathon
+        track_id: Optional filter by track ID
+        rank: Optional filter by rank
+        zerodb: ZeroDB client
+
+    Returns:
+        List of prizes with total count and prize pool summary
+    """
+    logger.info(f"Listing prizes for hackathon {hackathon_id}")
+
+    service = PrizeService(zerodb)
+    result = await service.list_prizes(
+        hackathon_id=hackathon_id,
+        track_id=track_id,
+        rank=rank,
+    )
+
+    return PrizeListResponse(
+        prizes=[PrizeResponse(**prize) for prize in result["prizes"]],
+        total=result["total"],
+        hackathon_id=result["hackathon_id"],
+        total_prize_pool=result.get("total_prize_pool"),
+    )
+
+
+@router.get(
+    "/{hackathon_id}/prizes/{prize_id}",
+    response_model=PrizeResponse,
+    summary="Get prize",
+    description="""
+    Get a single prize by ID.
+
+    **Authentication Required:** No (public endpoint)
+    **Permissions:** Any user can view prizes
+    """,
+)
+async def get_prize(
+    hackathon_id: str,
+    prize_id: str,
+    zerodb: ZeroDBClient = Depends(get_zerodb_client),
+) -> PrizeResponse:
+    """
+    Get a single prize.
+
+    Args:
+        hackathon_id: UUID of the hackathon
+        prize_id: UUID of the prize
+        zerodb: ZeroDB client
+
+    Returns:
+        Prize data
+
+    Raises:
+        404: If prize not found
+    """
+    logger.info(f"Retrieving prize {prize_id}")
+
+    service = PrizeService(zerodb)
+    prize = await service.get_prize(hackathon_id, prize_id)
+
+    return PrizeResponse(**prize)
+
+
+@router.put(
+    "/{hackathon_id}/prizes/{prize_id}",
+    response_model=PrizeResponse,
+    summary="Update prize",
+    description="""
+    Update a prize's details.
+
+    **Authentication Required:** Yes
+    **Permissions:** ORGANIZER role for the hackathon
+
+    Only provided fields will be updated.
+    Rank must remain unique within the same scope.
+    """,
+)
+async def update_prize(
+    hackathon_id: str,
+    prize_id: str,
+    request: PrizeUpdateRequest,
+    current_user: Dict = Depends(get_current_user),
+    zerodb: ZeroDBClient = Depends(get_zerodb_client),
+) -> PrizeResponse:
+    """
+    Update a prize.
+
+    Args:
+        hackathon_id: UUID of the hackathon
+        prize_id: UUID of the prize
+        request: Prize update data
+        current_user: Authenticated user
+        zerodb: ZeroDB client
+
+    Returns:
+        Updated prize data
+
+    Raises:
+        403: If user is not an ORGANIZER
+        404: If prize or track not found
+        409: If rank conflicts
+    """
+    # Verify user is organizer
+    await check_organizer(hackathon_id, current_user["id"], zerodb)
+
+    logger.info(f"User {current_user['id']} updating prize {prize_id}")
+
+    # Build update dict (only include non-None fields)
+    update_data = {k: v for k, v in request.model_dump().items() if v is not None}
+
+    if not update_data:
+        # No fields to update, return current prize
+        service = PrizeService(zerodb)
+        prize = await service.get_prize(hackathon_id, prize_id)
+        return PrizeResponse(**prize)
+
+    service = PrizeService(zerodb)
+    prize = await service.update_prize(
+        hackathon_id=hackathon_id,
+        prize_id=prize_id,
+        update_data=update_data,
+    )
+
+    return PrizeResponse(**prize)
+
+
+@router.delete(
+    "/{hackathon_id}/prizes/{prize_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete prize",
+    description="""
+    Delete a prize.
+
+    **Authentication Required:** Yes
+    **Permissions:** ORGANIZER role for the hackathon
+
+    This is a hard delete operation and cannot be undone.
+    """,
+)
+async def delete_prize(
+    hackathon_id: str,
+    prize_id: str,
+    current_user: Dict = Depends(get_current_user),
+    zerodb: ZeroDBClient = Depends(get_zerodb_client),
+) -> None:
+    """
+    Delete a prize.
+
+    Args:
+        hackathon_id: UUID of the hackathon
+        prize_id: UUID of the prize
+        current_user: Authenticated user
+        zerodb: ZeroDB client
+
+    Raises:
+        403: If user is not an ORGANIZER
+        404: If prize not found
+    """
+    # Verify user is organizer
+    await check_organizer(hackathon_id, current_user["id"], zerodb)
+
+    logger.info(f"User {current_user['id']} deleting prize {prize_id}")
+
+    service = PrizeService(zerodb)
+    await service.delete_prize(hackathon_id, prize_id)
+
+    return None

--- a/python-api/api/schemas/prize.py
+++ b/python-api/api/schemas/prize.py
@@ -1,0 +1,192 @@
+"""
+Pydantic schemas for prize endpoints.
+
+Defines request and response models for hackathon prize management.
+Prizes represent awards for hackathon winners with amounts, ranks, and sponsor information.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class PrizeCreateRequest(BaseModel):
+    """
+    Request schema for creating a prize.
+
+    Attributes:
+        title: Prize title (required, 3-200 chars)
+        description: Detailed description of the prize (optional, max 2000 chars)
+        amount: Prize amount in the specified currency (optional)
+        currency: Currency code (default: USD, max 10 chars)
+        rank: Prize ranking (1=first place, 2=second, etc.)
+        track_id: Optional track ID for track-specific prizes
+        sponsor_name: Optional sponsor/company name providing the prize
+        display_order: Display order for sorting prizes (default: same as rank)
+    """
+    title: str = Field(..., min_length=3, max_length=200, description="Prize title")
+    description: Optional[str] = Field(None, max_length=2000, description="Prize description")
+    amount: Optional[Decimal] = Field(None, ge=0, description="Prize amount")
+    currency: str = Field(default="USD", max_length=10, description="Currency code")
+    rank: int = Field(..., ge=1, le=100, description="Prize ranking (1=first place)")
+    track_id: Optional[str] = Field(None, description="Track ID for track-specific prizes")
+    sponsor_name: Optional[str] = Field(None, max_length=200, description="Sponsor name")
+    display_order: Optional[int] = Field(None, ge=1, description="Display order for sorting")
+
+    @field_validator('title')
+    @classmethod
+    def validate_title(cls, v: str) -> str:
+        """Ensure title is not just whitespace."""
+        if not v.strip():
+            raise ValueError("Title cannot be empty or whitespace")
+        return v.strip()
+
+    @field_validator('sponsor_name')
+    @classmethod
+    def validate_sponsor_name(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure sponsor name is not just whitespace if provided."""
+        if v is not None and not v.strip():
+            raise ValueError("Sponsor name cannot be empty or whitespace")
+        return v.strip() if v else None
+
+    @field_validator('currency')
+    @classmethod
+    def validate_currency(cls, v: str) -> str:
+        """Ensure currency is uppercase and not whitespace."""
+        if not v.strip():
+            raise ValueError("Currency cannot be empty or whitespace")
+        return v.strip().upper()
+
+
+class PrizeUpdateRequest(BaseModel):
+    """
+    Request schema for updating a prize.
+
+    All fields are optional. Only provided fields will be updated.
+
+    Attributes:
+        title: Updated prize title
+        description: Updated description
+        amount: Updated prize amount
+        currency: Updated currency code
+        rank: Updated prize ranking
+        track_id: Updated track ID
+        sponsor_name: Updated sponsor name
+        display_order: Updated display order
+    """
+    title: Optional[str] = Field(None, min_length=3, max_length=200)
+    description: Optional[str] = Field(None, max_length=2000)
+    amount: Optional[Decimal] = Field(None, ge=0)
+    currency: Optional[str] = Field(None, max_length=10)
+    rank: Optional[int] = Field(None, ge=1, le=100)
+    track_id: Optional[str] = None
+    sponsor_name: Optional[str] = Field(None, max_length=200)
+    display_order: Optional[int] = Field(None, ge=1)
+
+    @field_validator('title')
+    @classmethod
+    def validate_title(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure title is not just whitespace if provided."""
+        if v is not None and not v.strip():
+            raise ValueError("Title cannot be empty or whitespace")
+        return v.strip() if v else None
+
+    @field_validator('sponsor_name')
+    @classmethod
+    def validate_sponsor_name(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure sponsor name is not just whitespace if provided."""
+        if v is not None and not v.strip():
+            raise ValueError("Sponsor name cannot be empty or whitespace")
+        return v.strip() if v else None
+
+    @field_validator('currency')
+    @classmethod
+    def validate_currency(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure currency is uppercase and not whitespace if provided."""
+        if v is not None and not v.strip():
+            raise ValueError("Currency cannot be empty or whitespace")
+        return v.strip().upper() if v else None
+
+
+class PrizeResponse(BaseModel):
+    """
+    Response schema for a single prize.
+
+    Attributes:
+        prize_id: Unique prize identifier (UUID)
+        hackathon_id: UUID of the parent hackathon
+        title: Prize title
+        description: Prize description
+        amount: Prize amount
+        currency: Currency code
+        rank: Prize ranking (1=first place, 2=second, etc.)
+        track_id: Optional track ID for track-specific prizes
+        sponsor_name: Optional sponsor name
+        display_order: Display order for sorting
+        created_at: Creation timestamp
+        updated_at: Last update timestamp
+    """
+    prize_id: str
+    hackathon_id: str
+    title: str
+    description: Optional[str]
+    amount: Optional[Decimal]
+    currency: str
+    rank: int
+    track_id: Optional[str]
+    sponsor_name: Optional[str]
+    display_order: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PrizeListResponse(BaseModel):
+    """
+    Response schema for listing prizes.
+
+    Attributes:
+        prizes: List of prize objects
+        total: Total number of prizes
+        hackathon_id: UUID of the parent hackathon
+        total_prize_pool: Sum of all prize amounts (grouped by currency)
+    """
+    prizes: List[PrizeResponse]
+    total: int = Field(..., ge=0, description="Total prizes")
+    hackathon_id: str
+    total_prize_pool: Optional[dict] = Field(
+        default=None,
+        description="Total prize pool by currency (e.g., {'USD': 50000, 'EUR': 10000})"
+    )
+
+
+class PrizeDeleteResponse(BaseModel):
+    """
+    Response schema for prize deletion.
+
+    Attributes:
+        success: Whether deletion was successful
+        prize_id: ID of deleted prize
+        message: Confirmation message
+    """
+    success: bool
+    prize_id: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    """
+    Standard error response schema.
+
+    Attributes:
+        error: Error type/message
+        detail: Additional error details
+        status_code: HTTP status code
+    """
+    error: str
+    detail: Optional[str] = None
+    status_code: int

--- a/python-api/services/prize_service.py
+++ b/python-api/services/prize_service.py
@@ -1,0 +1,590 @@
+"""
+Prize Service
+
+Business logic for managing hackathon prizes.
+Handles CRUD operations with validation, authorization checks, and prize pool calculations.
+"""
+
+import logging
+from datetime import datetime
+from decimal import Decimal
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+from integrations.zerodb.client import ZeroDBClient
+from integrations.zerodb.exceptions import (
+    ZeroDBError,
+    ZeroDBNotFound,
+    ZeroDBTimeoutError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PrizeService:
+    """Service for managing hackathon prizes."""
+
+    def __init__(self, zerodb_client: ZeroDBClient):
+        """
+        Initialize prize service.
+
+        Args:
+            zerodb_client: ZeroDB client instance
+        """
+        self.zerodb = zerodb_client
+
+    async def create_prize(
+        self,
+        hackathon_id: str,
+        title: str,
+        rank: int,
+        description: Optional[str] = None,
+        amount: Optional[Decimal] = None,
+        currency: str = "USD",
+        track_id: Optional[str] = None,
+        sponsor_name: Optional[str] = None,
+        display_order: Optional[int] = None,
+    ) -> Dict:
+        """
+        Create a new prize for a hackathon.
+
+        Args:
+            hackathon_id: UUID of the hackathon
+            title: Prize title
+            rank: Prize ranking (1=first place, 2=second, etc.)
+            description: Optional prize description
+            amount: Optional prize amount
+            currency: Currency code (default: USD)
+            track_id: Optional track ID for track-specific prizes
+            sponsor_name: Optional sponsor name
+            display_order: Optional display order (defaults to rank if not provided)
+
+        Returns:
+            Created prize record
+
+        Raises:
+            HTTPException: 404 if hackathon not found
+            HTTPException: 404 if track_id provided but track not found
+            HTTPException: 409 if rank conflicts with existing prize for same scope
+            HTTPException: 500 for database errors
+            HTTPException: 504 for timeout errors
+        """
+        try:
+            # Verify hackathon exists
+            hackathons = await self.zerodb.tables.query_rows(
+                "hackathons",
+                filter={"hackathon_id": hackathon_id, "is_deleted": False},
+            )
+
+            if not hackathons:
+                logger.warning(f"Hackathon {hackathon_id} not found")
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Hackathon {hackathon_id} not found",
+                )
+
+            # If track_id provided, verify track exists and belongs to hackathon
+            if track_id:
+                tracks = await self.zerodb.tables.query_rows(
+                    "tracks",
+                    filter={"track_id": track_id, "hackathon_id": hackathon_id},
+                )
+
+                if not tracks:
+                    logger.warning(
+                        f"Track {track_id} not found for hackathon {hackathon_id}"
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"Track {track_id} not found for this hackathon",
+                    )
+
+            # Check for rank uniqueness within the same scope
+            # (hackathon-level or track-level)
+            prize_filter = {
+                "hackathon_id": hackathon_id,
+                "rank": rank,
+            }
+
+            if track_id:
+                prize_filter["track_id"] = track_id
+            else:
+                # For hackathon-level prizes, ensure track_id is None
+                prize_filter["track_id"] = None
+
+            existing_prizes = await self.zerodb.tables.query_rows(
+                "prizes",
+                filter=prize_filter,
+            )
+
+            if existing_prizes:
+                scope = f"track {track_id}" if track_id else "hackathon"
+                logger.warning(
+                    f"Prize with rank {rank} already exists for {scope} in hackathon {hackathon_id}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"Prize with rank {rank} already exists for this {scope}",
+                )
+
+            # Create prize record
+            prize_id = str(uuid4())
+            now = datetime.utcnow()
+
+            # Use rank as display_order if not provided
+            if display_order is None:
+                display_order = rank
+
+            prize_data = {
+                "prize_id": prize_id,
+                "hackathon_id": hackathon_id,
+                "title": title,
+                "description": description,
+                "amount": str(amount) if amount is not None else None,
+                "currency": currency,
+                "rank": rank,
+                "track_id": track_id,
+                "sponsor_name": sponsor_name,
+                "display_order": display_order,
+                "created_at": now.isoformat(),
+                "updated_at": now.isoformat(),
+            }
+
+            await self.zerodb.tables.insert_rows("prizes", [prize_data])
+
+            logger.info(f"Created prize {prize_id} for hackathon {hackathon_id}")
+
+            # Convert amount back to Decimal for response
+            return {
+                "prize_id": prize_id,
+                "hackathon_id": hackathon_id,
+                "title": title,
+                "description": description,
+                "amount": amount,
+                "currency": currency,
+                "rank": rank,
+                "track_id": track_id,
+                "sponsor_name": sponsor_name,
+                "display_order": display_order,
+                "created_at": now,
+                "updated_at": now,
+            }
+
+        except HTTPException:
+            raise
+
+        except ZeroDBTimeoutError as e:
+            logger.error(f"Timeout creating prize: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="Request timed out. Please try again.",
+            )
+
+        except (ZeroDBError, ZeroDBNotFound) as e:
+            logger.error(f"Database error creating prize: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create prize. Please contact support.",
+            )
+
+        except Exception as e:
+            logger.error(f"Unexpected error creating prize: {str(e)}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An unexpected error occurred. Please contact support.",
+            )
+
+    async def list_prizes(
+        self,
+        hackathon_id: str,
+        track_id: Optional[str] = None,
+        rank: Optional[int] = None,
+    ) -> Dict:
+        """
+        List all prizes for a hackathon with optional filters.
+
+        Args:
+            hackathon_id: UUID of the hackathon
+            track_id: Optional filter by track ID
+            rank: Optional filter by rank
+
+        Returns:
+            Dict with prizes list, total count, hackathon_id, and total_prize_pool
+
+        Raises:
+            HTTPException: 404 if hackathon not found
+            HTTPException: 500 for database errors
+            HTTPException: 504 for timeout errors
+        """
+        try:
+            # Verify hackathon exists
+            hackathons = await self.zerodb.tables.query_rows(
+                "hackathons",
+                filter={"hackathon_id": hackathon_id, "is_deleted": False},
+            )
+
+            if not hackathons:
+                logger.warning(f"Hackathon {hackathon_id} not found")
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Hackathon {hackathon_id} not found",
+                )
+
+            # Build query filter
+            prize_filter: Dict = {"hackathon_id": hackathon_id}
+
+            if track_id is not None:
+                prize_filter["track_id"] = track_id
+
+            if rank is not None:
+                prize_filter["rank"] = rank
+
+            # Query prizes
+            prizes = await self.zerodb.tables.query_rows(
+                "prizes",
+                filter=prize_filter,
+            )
+
+            # Parse datetime strings and amounts
+            for prize in prizes:
+                if "created_at" in prize and isinstance(prize["created_at"], str):
+                    prize["created_at"] = datetime.fromisoformat(prize["created_at"])
+                if "updated_at" in prize and isinstance(prize["updated_at"], str):
+                    prize["updated_at"] = datetime.fromisoformat(prize["updated_at"])
+                if "amount" in prize and prize["amount"] is not None:
+                    prize["amount"] = Decimal(str(prize["amount"]))
+
+            # Sort by display_order, then rank
+            prizes.sort(key=lambda x: (x.get("display_order", 999), x.get("rank", 999)))
+
+            # Calculate total prize pool by currency
+            prize_pool = {}
+            for prize in prizes:
+                if prize.get("amount") is not None:
+                    currency = prize.get("currency", "USD")
+                    amount = prize["amount"]
+                    prize_pool[currency] = prize_pool.get(currency, Decimal(0)) + amount
+
+            # Convert Decimal to float for JSON serialization
+            prize_pool_json = {k: float(v) for k, v in prize_pool.items()}
+
+            logger.info(f"Retrieved {len(prizes)} prizes for hackathon {hackathon_id}")
+
+            return {
+                "prizes": prizes,
+                "total": len(prizes),
+                "hackathon_id": hackathon_id,
+                "total_prize_pool": prize_pool_json if prize_pool_json else None,
+            }
+
+        except HTTPException:
+            raise
+
+        except ZeroDBTimeoutError as e:
+            logger.error(f"Timeout listing prizes: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="Request timed out. Please try again.",
+            )
+
+        except (ZeroDBError, ZeroDBNotFound) as e:
+            logger.error(f"Database error listing prizes: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retrieve prizes. Please contact support.",
+            )
+
+        except Exception as e:
+            logger.error(f"Unexpected error listing prizes: {str(e)}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An unexpected error occurred. Please contact support.",
+            )
+
+    async def get_prize(self, hackathon_id: str, prize_id: str) -> Dict:
+        """
+        Get a specific prize by ID.
+
+        Args:
+            hackathon_id: UUID of the hackathon
+            prize_id: UUID of the prize
+
+        Returns:
+            Prize record
+
+        Raises:
+            HTTPException: 404 if prize not found or doesn't belong to hackathon
+            HTTPException: 500 for database errors
+            HTTPException: 504 for timeout errors
+        """
+        try:
+            # Query prize
+            prizes = await self.zerodb.tables.query_rows(
+                "prizes",
+                filter={"prize_id": prize_id, "hackathon_id": hackathon_id},
+            )
+
+            if not prizes:
+                logger.warning(
+                    f"Prize {prize_id} not found for hackathon {hackathon_id}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Prize {prize_id} not found",
+                )
+
+            prize = prizes[0]
+
+            # Parse datetime strings and amount
+            if "created_at" in prize and isinstance(prize["created_at"], str):
+                prize["created_at"] = datetime.fromisoformat(prize["created_at"])
+            if "updated_at" in prize and isinstance(prize["updated_at"], str):
+                prize["updated_at"] = datetime.fromisoformat(prize["updated_at"])
+            if "amount" in prize and prize["amount"] is not None:
+                prize["amount"] = Decimal(str(prize["amount"]))
+
+            logger.info(f"Retrieved prize {prize_id}")
+            return prize
+
+        except HTTPException:
+            raise
+
+        except ZeroDBTimeoutError as e:
+            logger.error(f"Timeout getting prize: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="Request timed out. Please try again.",
+            )
+
+        except (ZeroDBError, ZeroDBNotFound) as e:
+            logger.error(f"Database error getting prize: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retrieve prize. Please contact support.",
+            )
+
+        except Exception as e:
+            logger.error(f"Unexpected error getting prize: {str(e)}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An unexpected error occurred. Please contact support.",
+            )
+
+    async def update_prize(
+        self,
+        hackathon_id: str,
+        prize_id: str,
+        update_data: Dict,
+    ) -> Dict:
+        """
+        Update a prize.
+
+        Args:
+            hackathon_id: UUID of the hackathon
+            prize_id: UUID of the prize
+            update_data: Fields to update
+
+        Returns:
+            Updated prize record
+
+        Raises:
+            HTTPException: 404 if prize not found
+            HTTPException: 404 if track_id updated to invalid track
+            HTTPException: 409 if rank conflicts with existing prize
+            HTTPException: 500 for database errors
+            HTTPException: 504 for timeout errors
+        """
+        try:
+            # Verify prize exists and belongs to hackathon
+            prizes = await self.zerodb.tables.query_rows(
+                "prizes",
+                filter={"prize_id": prize_id, "hackathon_id": hackathon_id},
+            )
+
+            if not prizes:
+                logger.warning(
+                    f"Prize {prize_id} not found for hackathon {hackathon_id}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Prize {prize_id} not found",
+                )
+
+            current_prize = prizes[0]
+
+            # If track_id is being updated, verify the new track exists
+            if "track_id" in update_data and update_data["track_id"] is not None:
+                tracks = await self.zerodb.tables.query_rows(
+                    "tracks",
+                    filter={
+                        "track_id": update_data["track_id"],
+                        "hackathon_id": hackathon_id,
+                    },
+                )
+
+                if not tracks:
+                    logger.warning(
+                        f"Track {update_data['track_id']} not found for hackathon {hackathon_id}"
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"Track {update_data['track_id']} not found for this hackathon",
+                    )
+
+            # If rank or track_id is being updated, check for conflicts
+            if "rank" in update_data or "track_id" in update_data:
+                new_rank = update_data.get("rank", current_prize.get("rank"))
+                new_track_id = update_data.get("track_id", current_prize.get("track_id"))
+
+                # Build conflict check filter
+                conflict_filter = {
+                    "hackathon_id": hackathon_id,
+                    "rank": new_rank,
+                }
+
+                if new_track_id:
+                    conflict_filter["track_id"] = new_track_id
+                else:
+                    conflict_filter["track_id"] = None
+
+                existing_prizes = await self.zerodb.tables.query_rows(
+                    "prizes",
+                    filter=conflict_filter,
+                )
+
+                # Check if conflict exists with a different prize
+                if existing_prizes and existing_prizes[0].get("prize_id") != prize_id:
+                    scope = f"track {new_track_id}" if new_track_id else "hackathon"
+                    logger.warning(
+                        f"Prize with rank {new_rank} already exists for {scope} in hackathon {hackathon_id}"
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=f"Prize with rank {new_rank} already exists for this {scope}",
+                    )
+
+            # Convert Decimal to string for storage if amount is being updated
+            if "amount" in update_data and update_data["amount"] is not None:
+                update_data["amount"] = str(update_data["amount"])
+
+            # Update prize
+            update_data["updated_at"] = datetime.utcnow().isoformat()
+
+            await self.zerodb.tables.update_rows(
+                "prizes",
+                filter={"prize_id": prize_id},
+                data=update_data,
+            )
+
+            # Retrieve updated prize
+            updated_prizes = await self.zerodb.tables.query_rows(
+                "prizes",
+                filter={"prize_id": prize_id},
+            )
+
+            prize = updated_prizes[0]
+
+            # Parse datetime strings and amount
+            if "created_at" in prize and isinstance(prize["created_at"], str):
+                prize["created_at"] = datetime.fromisoformat(prize["created_at"])
+            if "updated_at" in prize and isinstance(prize["updated_at"], str):
+                prize["updated_at"] = datetime.fromisoformat(prize["updated_at"])
+            if "amount" in prize and prize["amount"] is not None:
+                prize["amount"] = Decimal(str(prize["amount"]))
+
+            logger.info(f"Updated prize {prize_id}")
+            return prize
+
+        except HTTPException:
+            raise
+
+        except ZeroDBTimeoutError as e:
+            logger.error(f"Timeout updating prize: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="Request timed out. Please try again.",
+            )
+
+        except (ZeroDBError, ZeroDBNotFound) as e:
+            logger.error(f"Database error updating prize: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to update prize. Please contact support.",
+            )
+
+        except Exception as e:
+            logger.error(f"Unexpected error updating prize: {str(e)}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An unexpected error occurred. Please contact support.",
+            )
+
+    async def delete_prize(self, hackathon_id: str, prize_id: str) -> Dict:
+        """
+        Delete a prize.
+
+        Args:
+            hackathon_id: UUID of the hackathon
+            prize_id: UUID of the prize
+
+        Returns:
+            Deletion confirmation
+
+        Raises:
+            HTTPException: 404 if prize not found
+            HTTPException: 500 for database errors
+            HTTPException: 504 for timeout errors
+        """
+        try:
+            # Verify prize exists and belongs to hackathon
+            prizes = await self.zerodb.tables.query_rows(
+                "prizes",
+                filter={"prize_id": prize_id, "hackathon_id": hackathon_id},
+            )
+
+            if not prizes:
+                logger.warning(
+                    f"Prize {prize_id} not found for hackathon {hackathon_id}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Prize {prize_id} not found",
+                )
+
+            # Delete prize
+            await self.zerodb.tables.delete_rows(
+                "prizes",
+                filter={"prize_id": prize_id},
+            )
+
+            logger.info(f"Deleted prize {prize_id}")
+            return {
+                "success": True,
+                "prize_id": prize_id,
+                "message": "Prize successfully deleted",
+            }
+
+        except HTTPException:
+            raise
+
+        except ZeroDBTimeoutError as e:
+            logger.error(f"Timeout deleting prize: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="Request timed out. Please try again.",
+            )
+
+        except (ZeroDBError, ZeroDBNotFound) as e:
+            logger.error(f"Database error deleting prize: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to delete prize. Please contact support.",
+            )
+
+        except Exception as e:
+            logger.error(f"Unexpected error deleting prize: {str(e)}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An unexpected error occurred. Please contact support.",
+            )

--- a/python-api/tests/test_prize_service.py
+++ b/python-api/tests/test_prize_service.py
@@ -1,0 +1,572 @@
+"""
+Tests for Prize Service Business Logic
+
+Tests service-level logic for prize management with database operations.
+"""
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from services.prize_service import PrizeService
+
+
+@pytest.fixture
+def mock_zerodb_client():
+    """Mock ZeroDB client"""
+    return AsyncMock()
+
+
+@pytest.fixture
+def prize_service(mock_zerodb_client):
+    """Prize service instance with mocked ZeroDB"""
+    return PrizeService(mock_zerodb_client)
+
+
+class TestCreatePrize:
+    """Test create_prize service method"""
+
+    @pytest.mark.asyncio
+    async def test_create_prize_success(self, prize_service, mock_zerodb_client):
+        """Should create prize successfully"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+
+        # Mock hackathon exists
+        mock_zerodb_client.tables.query_rows.return_value = [
+            {"hackathon_id": hackathon_id, "is_deleted": False}
+        ]
+
+        # Mock no duplicate prizes
+        async def mock_query(table, filter):
+            if table == "hackathons":
+                return [{"hackathon_id": hackathon_id, "is_deleted": False}]
+            elif table == "prizes":
+                return []  # No existing prizes
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+        mock_zerodb_client.tables.insert_rows.return_value = None
+
+        # Act
+        result = await prize_service.create_prize(
+            hackathon_id=hackathon_id,
+            title="Grand Prize",
+            rank=1,
+            amount=Decimal("10000.00"),
+            currency="USD",
+        )
+
+        # Assert
+        assert result["title"] == "Grand Prize"
+        assert result["rank"] == 1
+        assert result["amount"] == Decimal("10000.00")
+        assert result["currency"] == "USD"
+        assert result["hackathon_id"] == hackathon_id
+
+    @pytest.mark.asyncio
+    async def test_create_prize_hackathon_not_found(
+        self, prize_service, mock_zerodb_client
+    ):
+        """Should raise 404 when hackathon not found"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        mock_zerodb_client.tables.query_rows.return_value = []  # Hackathon not found
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await prize_service.create_prize(
+                hackathon_id=hackathon_id,
+                title="Grand Prize",
+                rank=1,
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_create_prize_duplicate_rank(
+        self, prize_service, mock_zerodb_client
+    ):
+        """Should raise 409 when rank already exists"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if table == "hackathons":
+                return [{"hackathon_id": hackathon_id, "is_deleted": False}]
+            elif table == "prizes" and filter.get("rank") == 1:
+                return [
+                    {"prize_id": str(uuid.uuid4()), "rank": 1}
+                ]  # Duplicate rank
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await prize_service.create_prize(
+                hackathon_id=hackathon_id,
+                title="Grand Prize",
+                rank=1,
+            )
+
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_create_prize_with_track(self, prize_service, mock_zerodb_client):
+        """Should create track-specific prize"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        track_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if table == "hackathons":
+                return [{"hackathon_id": hackathon_id, "is_deleted": False}]
+            elif table == "tracks":
+                return [
+                    {"track_id": track_id, "hackathon_id": hackathon_id}
+                ]  # Track exists
+            elif table == "prizes":
+                return []  # No duplicates
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+        mock_zerodb_client.tables.insert_rows.return_value = None
+
+        # Act
+        result = await prize_service.create_prize(
+            hackathon_id=hackathon_id,
+            title="Best AI Project",
+            rank=1,
+            track_id=track_id,
+        )
+
+        # Assert
+        assert result["track_id"] == track_id
+
+
+class TestListPrizes:
+    """Test list_prizes service method"""
+
+    @pytest.mark.asyncio
+    async def test_list_prizes_success(self, prize_service, mock_zerodb_client):
+        """Should list prizes with prize pool"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if table == "hackathons":
+                return [{"hackathon_id": hackathon_id, "is_deleted": False}]
+            elif table == "prizes":
+                return [
+                    {
+                        "prize_id": str(uuid.uuid4()),
+                        "hackathon_id": hackathon_id,
+                        "title": "Grand Prize",
+                        "amount": "10000.00",
+                        "currency": "USD",
+                        "rank": 1,
+                        "display_order": 1,
+                        "created_at": "2024-01-01T00:00:00",
+                        "updated_at": "2024-01-01T00:00:00",
+                    },
+                    {
+                        "prize_id": str(uuid.uuid4()),
+                        "hackathon_id": hackathon_id,
+                        "title": "Runner Up",
+                        "amount": "5000.00",
+                        "currency": "USD",
+                        "rank": 2,
+                        "display_order": 2,
+                        "created_at": "2024-01-01T00:00:00",
+                        "updated_at": "2024-01-01T00:00:00",
+                    },
+                ]
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+
+        # Act
+        result = await prize_service.list_prizes(hackathon_id)
+
+        # Assert
+        assert result["total"] == 2
+        assert len(result["prizes"]) == 2
+        assert result["total_prize_pool"]["USD"] == 15000.00
+
+
+class TestGetPrize:
+    """Test get_prize service method"""
+
+    @pytest.mark.asyncio
+    async def test_get_prize_success(self, prize_service, mock_zerodb_client):
+        """Should get prize by ID"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_zerodb_client.tables.query_rows.return_value = [
+            {
+                "prize_id": prize_id,
+                "hackathon_id": hackathon_id,
+                "title": "Grand Prize",
+                "amount": "10000.00",
+                "currency": "USD",
+                "rank": 1,
+                "display_order": 1,
+                "created_at": "2024-01-01T00:00:00",
+                "updated_at": "2024-01-01T00:00:00",
+            }
+        ]
+
+        # Act
+        result = await prize_service.get_prize(hackathon_id, prize_id)
+
+        # Assert
+        assert result["prize_id"] == prize_id
+        assert result["title"] == "Grand Prize"
+
+    @pytest.mark.asyncio
+    async def test_get_prize_not_found(self, prize_service, mock_zerodb_client):
+        """Should raise 404 when prize not found"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+        mock_zerodb_client.tables.query_rows.return_value = []
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await prize_service.get_prize(hackathon_id, prize_id)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestUpdatePrize:
+    """Test update_prize service method"""
+
+    @pytest.mark.asyncio
+    async def test_update_prize_success(self, prize_service, mock_zerodb_client):
+        """Should update prize successfully"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if "prize_id" in filter:
+                return [
+                    {
+                        "prize_id": prize_id,
+                        "hackathon_id": hackathon_id,
+                        "title": "Updated Prize",
+                        "rank": 1,
+                        "amount": "15000.00",
+                        "currency": "USD",
+                        "display_order": 1,
+                        "created_at": "2024-01-01T00:00:00",
+                        "updated_at": "2024-01-02T00:00:00",
+                    }
+                ]
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+        mock_zerodb_client.tables.update_rows.return_value = None
+
+        # Act
+        result = await prize_service.update_prize(
+            hackathon_id=hackathon_id,
+            prize_id=prize_id,
+            update_data={"title": "Updated Prize", "amount": Decimal("15000.00")},
+        )
+
+        # Assert
+        assert result["title"] == "Updated Prize"
+
+    @pytest.mark.asyncio
+    async def test_update_prize_not_found(self, prize_service, mock_zerodb_client):
+        """Should raise 404 when prize not found"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+        mock_zerodb_client.tables.query_rows.return_value = []
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await prize_service.update_prize(
+                hackathon_id=hackathon_id,
+                prize_id=prize_id,
+                update_data={"title": "Updated"},
+            )
+
+        assert exc_info.value.status_code == 404
+
+
+class TestDeletePrize:
+    """Test delete_prize service method"""
+
+    @pytest.mark.asyncio
+    async def test_delete_prize_success(self, prize_service, mock_zerodb_client):
+        """Should delete prize successfully"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_zerodb_client.tables.query_rows.return_value = [
+            {"prize_id": prize_id, "hackathon_id": hackathon_id}
+        ]
+        mock_zerodb_client.tables.delete_rows.return_value = None
+
+        # Act
+        result = await prize_service.delete_prize(hackathon_id, prize_id)
+
+        # Assert
+        assert result["success"] is True
+        assert result["prize_id"] == prize_id
+
+    @pytest.mark.asyncio
+    async def test_delete_prize_not_found(self, prize_service, mock_zerodb_client):
+        """Should raise 404 when prize not found"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+        mock_zerodb_client.tables.query_rows.return_value = []
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await prize_service.delete_prize(hackathon_id, prize_id)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling"""
+
+    @pytest.mark.asyncio
+    async def test_create_prize_with_display_order(
+        self, prize_service, mock_zerodb_client
+    ):
+        """Should create prize with custom display order"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if table == "hackathons":
+                return [{"hackathon_id": hackathon_id, "is_deleted": False}]
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+        mock_zerodb_client.tables.insert_rows.return_value = None
+
+        # Act
+        result = await prize_service.create_prize(
+            hackathon_id=hackathon_id,
+            title="Special Prize",
+            rank=3,
+            display_order=1,
+        )
+
+        # Assert
+        assert result["display_order"] == 1
+        assert result["rank"] == 3
+
+    @pytest.mark.asyncio
+    async def test_create_prize_track_not_found(
+        self, prize_service, mock_zerodb_client
+    ):
+        """Should raise 404 when track not found"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        track_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if table == "hackathons":
+                return [{"hackathon_id": hackathon_id, "is_deleted": False}]
+            elif table == "tracks":
+                return []  # Track not found
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await prize_service.create_prize(
+                hackathon_id=hackathon_id,
+                title="Track Prize",
+                rank=1,
+                track_id=track_id,
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_list_prizes_filter_by_track(
+        self, prize_service, mock_zerodb_client
+    ):
+        """Should filter prizes by track_id"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        track_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if table == "hackathons":
+                return [{"hackathon_id": hackathon_id, "is_deleted": False}]
+            elif table == "prizes" and filter.get("track_id") == track_id:
+                return [
+                    {
+                        "prize_id": str(uuid.uuid4()),
+                        "hackathon_id": hackathon_id,
+                        "title": "Track Prize",
+                        "track_id": track_id,
+                        "amount": "3000.00",
+                        "currency": "USD",
+                        "rank": 1,
+                        "display_order": 1,
+                        "created_at": "2024-01-01T00:00:00",
+                        "updated_at": "2024-01-01T00:00:00",
+                    }
+                ]
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+
+        # Act
+        result = await prize_service.list_prizes(hackathon_id, track_id=track_id)
+
+        # Assert
+        assert result["total"] == 1
+        assert result["prizes"][0]["track_id"] == track_id
+
+    @pytest.mark.asyncio
+    async def test_list_prizes_filter_by_rank(
+        self, prize_service, mock_zerodb_client
+    ):
+        """Should filter prizes by rank"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if table == "hackathons":
+                return [{"hackathon_id": hackathon_id, "is_deleted": False}]
+            elif table == "prizes" and filter.get("rank") == 1:
+                return [
+                    {
+                        "prize_id": str(uuid.uuid4()),
+                        "hackathon_id": hackathon_id,
+                        "title": "First Place",
+                        "rank": 1,
+                        "amount": "10000.00",
+                        "currency": "USD",
+                        "display_order": 1,
+                        "created_at": "2024-01-01T00:00:00",
+                        "updated_at": "2024-01-01T00:00:00",
+                    }
+                ]
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+
+        # Act
+        result = await prize_service.list_prizes(hackathon_id, rank=1)
+
+        # Assert
+        assert result["total"] == 1
+        assert result["prizes"][0]["rank"] == 1
+
+    @pytest.mark.asyncio
+    async def test_update_prize_with_track_change(
+        self, prize_service, mock_zerodb_client
+    ):
+        """Should update prize with track change"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+        new_track_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if "prize_id" in filter and table == "prizes":
+                if len([k for k in filter.keys() if k != "prize_id"]) == 1:
+                    # Initial query for existing prize
+                    return [
+                        {
+                            "prize_id": prize_id,
+                            "hackathon_id": hackathon_id,
+                            "rank": 1,
+                            "track_id": None,
+                        }
+                    ]
+                else:
+                    # Updated prize query
+                    return [
+                        {
+                            "prize_id": prize_id,
+                            "hackathon_id": hackathon_id,
+                            "title": "Updated Prize",
+                            "rank": 1,
+                            "track_id": new_track_id,
+                            "amount": "10000.00",
+                            "currency": "USD",
+                            "display_order": 1,
+                            "created_at": "2024-01-01T00:00:00",
+                            "updated_at": "2024-01-02T00:00:00",
+                        }
+                    ]
+            elif table == "tracks":
+                return [
+                    {"track_id": new_track_id, "hackathon_id": hackathon_id}
+                ]  # Track exists
+            elif table == "prizes" and filter.get("track_id") == new_track_id:
+                return []  # No rank conflicts
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+        mock_zerodb_client.tables.update_rows.return_value = None
+
+        # Act
+        result = await prize_service.update_prize(
+            hackathon_id=hackathon_id,
+            prize_id=prize_id,
+            update_data={"track_id": new_track_id},
+        )
+
+        # Assert
+        assert result["track_id"] == new_track_id
+
+    @pytest.mark.asyncio
+    async def test_update_prize_rank_conflict(
+        self, prize_service, mock_zerodb_client
+    ):
+        """Should raise 409 when updating to conflicting rank"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+        other_prize_id = str(uuid.uuid4())
+
+        async def mock_query(table, filter):
+            if "prize_id" in filter and len(filter) == 2:
+                # Initial prize query
+                return [
+                    {
+                        "prize_id": prize_id,
+                        "hackathon_id": hackathon_id,
+                        "rank": 2,
+                    }
+                ]
+            elif "rank" in filter and filter.get("rank") == 1:
+                # Check for rank conflict
+                return [
+                    {"prize_id": other_prize_id, "rank": 1}
+                ]  # Different prize has rank 1
+            return []
+
+        mock_zerodb_client.tables.query_rows.side_effect = mock_query
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            await prize_service.update_prize(
+                hackathon_id=hackathon_id,
+                prize_id=prize_id,
+                update_data={"rank": 1},
+            )
+
+        assert exc_info.value.status_code == 409

--- a/python-api/tests/test_prizes.py
+++ b/python-api/tests/test_prizes.py
@@ -1,0 +1,727 @@
+"""
+Tests for Prizes API Endpoints
+
+Tests all prize CRUD endpoints for hackathon prize management.
+Uses TestClient for integration testing with mocked dependencies.
+"""
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from api.routes.prizes import get_current_user, get_zerodb_client, router
+from fastapi import FastAPI, status
+from fastapi.testclient import TestClient
+from integrations.zerodb.exceptions import ZeroDBError, ZeroDBNotFound
+
+
+# Create test app with prizes router
+app = FastAPI()
+app.include_router(router)
+
+
+@pytest.fixture
+def mock_user():
+    """Mock authenticated user"""
+    return {
+        "id": str(uuid.uuid4()),
+        "email": "organizer@example.com",
+        "name": "Test Organizer",
+    }
+
+
+@pytest.fixture
+def mock_zerodb_client():
+    """Mock ZeroDB client"""
+    return AsyncMock()
+
+
+@pytest.fixture
+def client(mock_user, mock_zerodb_client):
+    """Test client with dependency overrides"""
+
+    async def override_get_current_user():
+        return mock_user
+
+    async def override_get_zerodb_client():
+        return mock_zerodb_client
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_zerodb_client] = override_get_zerodb_client
+
+    yield TestClient(app)
+
+    # Clean up
+    app.dependency_overrides.clear()
+
+
+class TestCreatePrizeEndpoint:
+    """Test POST /hackathons/{hackathon_id}/prizes - Create prize"""
+
+    @patch("api.routes.prizes.PrizeService.create_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_create_prize_success(
+        self, mock_check_organizer, mock_create, client, mock_user
+    ):
+        """Should create prize and return 201"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        mock_create.return_value = {
+            "prize_id": prize_id,
+            "hackathon_id": hackathon_id,
+            "title": "Grand Prize",
+            "description": "Overall winner",
+            "amount": Decimal("10000.00"),
+            "currency": "USD",
+            "rank": 1,
+            "track_id": None,
+            "sponsor_name": "Tech Corp",
+            "display_order": 1,
+            "created_at": "2024-01-01T00:00:00",
+            "updated_at": "2024-01-01T00:00:00",
+        }
+
+        # Act
+        response = client.post(
+            f"/api/v1/hackathons/{hackathon_id}/prizes",
+            json={
+                "title": "Grand Prize",
+                "description": "Overall winner",
+                "amount": 10000.00,
+                "currency": "USD",
+                "rank": 1,
+                "sponsor_name": "Tech Corp",
+            },
+        )
+
+        # Assert
+        assert response.status_code == 201
+        data = response.json()
+        assert data["prize_id"] == prize_id
+        assert data["title"] == "Grand Prize"
+        assert data["rank"] == 1
+        assert data["amount"] == "10000.00"
+        assert data["currency"] == "USD"
+
+    @patch("api.routes.prizes.PrizeService.create_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_create_prize_track_specific(
+        self, mock_check_organizer, mock_create, client
+    ):
+        """Should create track-specific prize"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+        track_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        mock_create.return_value = {
+            "prize_id": prize_id,
+            "hackathon_id": hackathon_id,
+            "title": "Best AI Project",
+            "description": "Most innovative AI implementation",
+            "amount": Decimal("5000.00"),
+            "currency": "USD",
+            "rank": 1,
+            "track_id": track_id,
+            "sponsor_name": None,
+            "display_order": 1,
+            "created_at": "2024-01-01T00:00:00",
+            "updated_at": "2024-01-01T00:00:00",
+        }
+
+        # Act
+        response = client.post(
+            f"/api/v1/hackathons/{hackathon_id}/prizes",
+            json={
+                "title": "Best AI Project",
+                "description": "Most innovative AI implementation",
+                "amount": 5000.00,
+                "currency": "USD",
+                "rank": 1,
+                "track_id": track_id,
+            },
+        )
+
+        # Assert
+        assert response.status_code == 201
+        data = response.json()
+        assert data["track_id"] == track_id
+        assert data["title"] == "Best AI Project"
+
+    @patch("api.routes.prizes.PrizeService.create_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_create_prize_minimal_fields(
+        self, mock_check_organizer, mock_create, client
+    ):
+        """Should create prize with only required fields"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        mock_create.return_value = {
+            "prize_id": prize_id,
+            "hackathon_id": hackathon_id,
+            "title": "Runner Up",
+            "description": None,
+            "amount": None,
+            "currency": "USD",
+            "rank": 2,
+            "track_id": None,
+            "sponsor_name": None,
+            "display_order": 2,
+            "created_at": "2024-01-01T00:00:00",
+            "updated_at": "2024-01-01T00:00:00",
+        }
+
+        # Act
+        response = client.post(
+            f"/api/v1/hackathons/{hackathon_id}/prizes",
+            json={"title": "Runner Up", "rank": 2},
+        )
+
+        # Assert
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "Runner Up"
+        assert data["rank"] == 2
+        assert data["amount"] is None
+
+    @patch("api.routes.prizes.check_organizer")
+    def test_create_prize_invalid_title_too_short(self, mock_check_organizer, client):
+        """Should reject prize with title too short"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        mock_check_organizer.return_value = None
+
+        # Act
+        response = client.post(
+            f"/api/v1/hackathons/{hackathon_id}/prizes",
+            json={"title": "AI", "rank": 1},  # Less than 3 chars
+        )
+
+        # Assert
+        assert response.status_code == 422
+
+    @patch("api.routes.prizes.check_organizer")
+    def test_create_prize_invalid_rank_zero(self, mock_check_organizer, client):
+        """Should reject prize with invalid rank"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        mock_check_organizer.return_value = None
+
+        # Act
+        response = client.post(
+            f"/api/v1/hackathons/{hackathon_id}/prizes",
+            json={"title": "Grand Prize", "rank": 0},  # Rank must be >= 1
+        )
+
+        # Assert
+        assert response.status_code == 422
+
+    @patch("api.routes.prizes.check_organizer")
+    def test_create_prize_invalid_amount_negative(self, mock_check_organizer, client):
+        """Should reject prize with negative amount"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        mock_check_organizer.return_value = None
+
+        # Act
+        response = client.post(
+            f"/api/v1/hackathons/{hackathon_id}/prizes",
+            json={"title": "Grand Prize", "rank": 1, "amount": -1000},
+        )
+
+        # Assert
+        assert response.status_code == 422
+
+
+class TestListPrizesEndpoint:
+    """Test GET /hackathons/{hackathon_id}/prizes - List prizes"""
+
+    @patch("api.routes.prizes.PrizeService.list_prizes")
+    def test_list_prizes_success(self, mock_list, client):
+        """Should return list of prizes with prize pool"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        prize1_id = str(uuid.uuid4())
+        prize2_id = str(uuid.uuid4())
+
+        mock_list.return_value = {
+            "prizes": [
+                {
+                    "prize_id": prize1_id,
+                    "hackathon_id": hackathon_id,
+                    "title": "Grand Prize",
+                    "description": "Overall winner",
+                    "amount": Decimal("10000.00"),
+                    "currency": "USD",
+                    "rank": 1,
+                    "track_id": None,
+                    "sponsor_name": "Tech Corp",
+                    "display_order": 1,
+                    "created_at": "2024-01-01T00:00:00",
+                    "updated_at": "2024-01-01T00:00:00",
+                },
+                {
+                    "prize_id": prize2_id,
+                    "hackathon_id": hackathon_id,
+                    "title": "Runner Up",
+                    "description": "Second place",
+                    "amount": Decimal("5000.00"),
+                    "currency": "USD",
+                    "rank": 2,
+                    "track_id": None,
+                    "sponsor_name": None,
+                    "display_order": 2,
+                    "created_at": "2024-01-02T00:00:00",
+                    "updated_at": "2024-01-02T00:00:00",
+                },
+            ],
+            "total": 2,
+            "hackathon_id": hackathon_id,
+            "total_prize_pool": {"USD": 15000.00},
+        }
+
+        # Act
+        response = client.get(f"/api/v1/hackathons/{hackathon_id}/prizes")
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["prizes"]) == 2
+        assert data["prizes"][0]["title"] == "Grand Prize"
+        assert data["prizes"][1]["title"] == "Runner Up"
+        assert data["total_prize_pool"]["USD"] == 15000.00
+
+    @patch("api.routes.prizes.PrizeService.list_prizes")
+    def test_list_prizes_empty(self, mock_list, client):
+        """Should return empty list when no prizes"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        mock_list.return_value = {
+            "prizes": [],
+            "total": 0,
+            "hackathon_id": hackathon_id,
+            "total_prize_pool": None,
+        }
+
+        # Act
+        response = client.get(f"/api/v1/hackathons/{hackathon_id}/prizes")
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert len(data["prizes"]) == 0
+        assert data["total_prize_pool"] is None
+
+    @patch("api.routes.prizes.PrizeService.list_prizes")
+    def test_list_prizes_filter_by_track(self, mock_list, client):
+        """Should filter prizes by track_id"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        track_id = str(uuid.uuid4())
+        prize_id = str(uuid.uuid4())
+
+        mock_list.return_value = {
+            "prizes": [
+                {
+                    "prize_id": prize_id,
+                    "hackathon_id": hackathon_id,
+                    "title": "Best AI Project",
+                    "description": "Track-specific prize",
+                    "amount": Decimal("3000.00"),
+                    "currency": "USD",
+                    "rank": 1,
+                    "track_id": track_id,
+                    "sponsor_name": None,
+                    "display_order": 1,
+                    "created_at": "2024-01-01T00:00:00",
+                    "updated_at": "2024-01-01T00:00:00",
+                }
+            ],
+            "total": 1,
+            "hackathon_id": hackathon_id,
+            "total_prize_pool": {"USD": 3000.00},
+        }
+
+        # Act
+        response = client.get(
+            f"/api/v1/hackathons/{hackathon_id}/prizes?track_id={track_id}"
+        )
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["prizes"][0]["track_id"] == track_id
+
+    @patch("api.routes.prizes.PrizeService.list_prizes")
+    def test_list_prizes_filter_by_rank(self, mock_list, client):
+        """Should filter prizes by rank"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+        prize_id = str(uuid.uuid4())
+
+        mock_list.return_value = {
+            "prizes": [
+                {
+                    "prize_id": prize_id,
+                    "hackathon_id": hackathon_id,
+                    "title": "Grand Prize",
+                    "description": "First place",
+                    "amount": Decimal("10000.00"),
+                    "currency": "USD",
+                    "rank": 1,
+                    "track_id": None,
+                    "sponsor_name": None,
+                    "display_order": 1,
+                    "created_at": "2024-01-01T00:00:00",
+                    "updated_at": "2024-01-01T00:00:00",
+                }
+            ],
+            "total": 1,
+            "hackathon_id": hackathon_id,
+            "total_prize_pool": {"USD": 10000.00},
+        }
+
+        # Act
+        response = client.get(f"/api/v1/hackathons/{hackathon_id}/prizes?rank=1")
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["prizes"][0]["rank"] == 1
+
+
+class TestGetPrizeEndpoint:
+    """Test GET /hackathons/{hackathon_id}/prizes/{prize_id} - Get prize"""
+
+    @patch("api.routes.prizes.PrizeService.get_prize")
+    def test_get_prize_success(self, mock_get, client):
+        """Should return single prize"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_get.return_value = {
+            "prize_id": prize_id,
+            "hackathon_id": hackathon_id,
+            "title": "Grand Prize",
+            "description": "Overall winner",
+            "amount": Decimal("10000.00"),
+            "currency": "USD",
+            "rank": 1,
+            "track_id": None,
+            "sponsor_name": "Tech Corp",
+            "display_order": 1,
+            "created_at": "2024-01-01T00:00:00",
+            "updated_at": "2024-01-01T00:00:00",
+        }
+
+        # Act
+        response = client.get(
+            f"/api/v1/hackathons/{hackathon_id}/prizes/{prize_id}"
+        )
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["prize_id"] == prize_id
+        assert data["title"] == "Grand Prize"
+        assert data["amount"] == "10000.00"
+
+    @patch("api.routes.prizes.PrizeService.get_prize")
+    def test_get_prize_not_found(self, mock_get, client):
+        """Should return 404 when prize not found"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+        from fastapi import HTTPException, status
+        mock_get.side_effect = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Prize {prize_id} not found"
+        )
+
+        # Act
+        response = client.get(
+            f"/api/v1/hackathons/{hackathon_id}/prizes/{prize_id}"
+        )
+
+        # Assert
+        assert response.status_code == 404
+
+
+class TestUpdatePrizeEndpoint:
+    """Test PUT /hackathons/{hackathon_id}/prizes/{prize_id} - Update prize"""
+
+    @patch("api.routes.prizes.PrizeService.update_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_update_prize_success(
+        self, mock_check_organizer, mock_update, client, mock_user
+    ):
+        """Should update prize and return updated data"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        mock_update.return_value = {
+            "prize_id": prize_id,
+            "hackathon_id": hackathon_id,
+            "title": "Updated Grand Prize",
+            "description": "Updated description",
+            "amount": Decimal("15000.00"),
+            "currency": "USD",
+            "rank": 1,
+            "track_id": None,
+            "sponsor_name": "New Sponsor",
+            "display_order": 1,
+            "created_at": "2024-01-01T00:00:00",
+            "updated_at": "2024-01-02T00:00:00",
+        }
+
+        # Act
+        response = client.put(
+            f"/api/v1/hackathons/{hackathon_id}/prizes/{prize_id}",
+            json={
+                "title": "Updated Grand Prize",
+                "description": "Updated description",
+                "amount": 15000.00,
+                "sponsor_name": "New Sponsor",
+            },
+        )
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["title"] == "Updated Grand Prize"
+        assert data["amount"] == "15000.00"
+        assert data["sponsor_name"] == "New Sponsor"
+
+    @patch("api.routes.prizes.PrizeService.get_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_update_prize_no_changes(self, mock_check_organizer, mock_get, client):
+        """Should return existing prize when no update data provided"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        mock_get.return_value = {
+            "prize_id": prize_id,
+            "hackathon_id": hackathon_id,
+            "title": "Grand Prize",
+            "description": "Original description",
+            "amount": Decimal("10000.00"),
+            "currency": "USD",
+            "rank": 1,
+            "track_id": None,
+            "sponsor_name": "Tech Corp",
+            "display_order": 1,
+            "created_at": "2024-01-01T00:00:00",
+            "updated_at": "2024-01-01T00:00:00",
+        }
+
+        # Act
+        response = client.put(
+            f"/api/v1/hackathons/{hackathon_id}/prizes/{prize_id}",
+            json={},
+        )
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["title"] == "Grand Prize"
+
+    @patch("api.routes.prizes.PrizeService.update_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_update_prize_change_rank(
+        self, mock_check_organizer, mock_update, client
+    ):
+        """Should successfully update prize rank"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        mock_update.return_value = {
+            "prize_id": prize_id,
+            "hackathon_id": hackathon_id,
+            "title": "Grand Prize",
+            "description": "Overall winner",
+            "amount": Decimal("10000.00"),
+            "currency": "USD",
+            "rank": 2,  # Changed from 1 to 2
+            "track_id": None,
+            "sponsor_name": "Tech Corp",
+            "display_order": 2,
+            "created_at": "2024-01-01T00:00:00",
+            "updated_at": "2024-01-02T00:00:00",
+        }
+
+        # Act
+        response = client.put(
+            f"/api/v1/hackathons/{hackathon_id}/prizes/{prize_id}",
+            json={"rank": 2},
+        )
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rank"] == 2
+
+
+class TestDeletePrizeEndpoint:
+    """Test DELETE /hackathons/{hackathon_id}/prizes/{prize_id} - Delete prize"""
+
+    @patch("api.routes.prizes.PrizeService.delete_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_delete_prize_success(
+        self, mock_check_organizer, mock_delete, client, mock_user
+    ):
+        """Should delete prize and return 204"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        mock_delete.return_value = None
+
+        # Act
+        response = client.delete(
+            f"/api/v1/hackathons/{hackathon_id}/prizes/{prize_id}"
+        )
+
+        # Assert
+        assert response.status_code == 204
+
+    @patch("api.routes.prizes.PrizeService.delete_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_delete_prize_not_found(
+        self, mock_check_organizer, mock_delete, client
+    ):
+        """Should return 404 when prize not found"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        from fastapi import HTTPException, status
+        mock_delete.side_effect = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Prize {prize_id} not found"
+        )
+
+        # Act
+        response = client.delete(
+            f"/api/v1/hackathons/{hackathon_id}/prizes/{prize_id}"
+        )
+
+        # Assert
+        assert response.status_code == 404
+
+
+class TestPrizeBusinessLogic:
+    """Test prize business logic and validation"""
+
+    @patch("api.routes.prizes.PrizeService.create_prize")
+    @patch("api.routes.prizes.check_organizer")
+    def test_prize_currency_uppercase_conversion(
+        self, mock_check_organizer, mock_create, client
+    ):
+        """Should convert currency to uppercase"""
+        # Arrange
+        prize_id = str(uuid.uuid4())
+        hackathon_id = str(uuid.uuid4())
+
+        mock_check_organizer.return_value = None
+        mock_create.return_value = {
+            "prize_id": prize_id,
+            "hackathon_id": hackathon_id,
+            "title": "Grand Prize",
+            "description": None,
+            "amount": Decimal("10000.00"),
+            "currency": "EUR",  # Stored as uppercase
+            "rank": 1,
+            "track_id": None,
+            "sponsor_name": None,
+            "display_order": 1,
+            "created_at": "2024-01-01T00:00:00",
+            "updated_at": "2024-01-01T00:00:00",
+        }
+
+        # Act
+        response = client.post(
+            f"/api/v1/hackathons/{hackathon_id}/prizes",
+            json={
+                "title": "Grand Prize",
+                "rank": 1,
+                "amount": 10000.00,
+                "currency": "eur",  # Lowercase input
+            },
+        )
+
+        # Assert
+        assert response.status_code == 201
+        data = response.json()
+        assert data["currency"] == "EUR"
+
+    @patch("api.routes.prizes.PrizeService.list_prizes")
+    def test_prize_pool_multiple_currencies(self, mock_list, client):
+        """Should calculate prize pool for multiple currencies"""
+        # Arrange
+        hackathon_id = str(uuid.uuid4())
+
+        mock_list.return_value = {
+            "prizes": [
+                {
+                    "prize_id": str(uuid.uuid4()),
+                    "hackathon_id": hackathon_id,
+                    "title": "USD Prize",
+                    "description": None,
+                    "amount": Decimal("10000.00"),
+                    "currency": "USD",
+                    "rank": 1,
+                    "track_id": None,
+                    "sponsor_name": None,
+                    "display_order": 1,
+                    "created_at": "2024-01-01T00:00:00",
+                    "updated_at": "2024-01-01T00:00:00",
+                },
+                {
+                    "prize_id": str(uuid.uuid4()),
+                    "hackathon_id": hackathon_id,
+                    "title": "EUR Prize",
+                    "description": None,
+                    "amount": Decimal("5000.00"),
+                    "currency": "EUR",
+                    "rank": 2,
+                    "track_id": None,
+                    "sponsor_name": None,
+                    "display_order": 2,
+                    "created_at": "2024-01-01T00:00:00",
+                    "updated_at": "2024-01-01T00:00:00",
+                },
+            ],
+            "total": 2,
+            "hackathon_id": hackathon_id,
+            "total_prize_pool": {"USD": 10000.00, "EUR": 5000.00},
+        }
+
+        # Act
+        response = client.get(f"/api/v1/hackathons/{hackathon_id}/prizes")
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_prize_pool"]["USD"] == 10000.00
+        assert data["total_prize_pool"]["EUR"] == 5000.00


### PR DESCRIPTION
## Summary
Implements comprehensive CRUD API for managing hackathon prizes.

Resolves #66

## API Endpoints
- POST /api/v1/hackathons/{id}/prizes - Create (ORGANIZER)
- GET /api/v1/hackathons/{id}/prizes - List (public)
- GET /api/v1/hackathons/{id}/prizes/{id} - Get (public)
- PUT /api/v1/hackathons/{id}/prizes/{id} - Update (ORGANIZER)
- DELETE /api/v1/hackathons/{id}/prizes/{id} - Delete (ORGANIZER)

## Features
- Track-specific prizes support
- Rank uniqueness validation
- Prize pool calculation by currency
- Filters: track_id, rank
- Auto-sort by display_order/rank

## Implementation
- api/schemas/prize.py - Models
- services/prize_service.py - Business logic
- api/routes/prizes.py - Endpoints
- tests/test_prizes.py - 19 tests
- tests/test_prize_service.py - 17 tests

## Test Coverage: 80%
- Routes: 100%
- Schemas: 88%
- Service: 73%
- 36 tests passing

## Test Execution Evidence
```
pytest tests/test_prizes.py tests/test_prize_service.py -v --cov
======================== 36 passed, 5 warnings in 0.18s ========================
Total Coverage: 80%
```
